### PR TITLE
Fix/schemakey metaclass

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -170,10 +170,13 @@ class DandiBaseModel(BaseModel, metaclass=DandiBaseModelMetaclass):
                 # In pydantic 1.8+ all Literals are mapped on to enum
                 # This presently breaks the schema editor UI. Revert
                 # to const when generating the schema.
+                # Note: this no longer happens with custom metaclass
                 if prop == "schemaKey":
-                    if len(value["enum"]) == 1:
+                    if "enum" in value and len(value["enum"]) == 1:
                         value["const"] = value["enum"][0]
                         del value["enum"]
+                    else:
+                        value["const"] = value["default"]
 
 
 class PropertyValue(DandiBaseModel):


### PR DESCRIPTION
Please see individual commit messages for some extra metadata.

Supplement to #6

May be we should drop that `enum` special handling altogether and then assignment of that `const`?

edit: FWIW tried to sort `dct` in metaclass for no effect on produced jsonschema