### PR TITLE
Prefix library versions with `v`

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -2,7 +2,7 @@
     "onlyPublishWithReleaseLabel": true,
     "baseBranch": "master",
     "author": "auto <auto@nil>",
-    "noVersionPrefix": true,
+    "noVersionPrefix": false,
     "plugins": [
         "git-tag",
         [

--- a/dandischema/_version.py
+++ b/dandischema/_version.py
@@ -42,9 +42,9 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = ""
-    cfg.versionfile_source = "nibabel/_version.py"
+    cfg.versionfile_source = "dandischema/_version.py"
     cfg.verbose = False
     return cfg
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ VCS = git
 style = pep440
 versionfile_source = dandischema/_version.py
 versionfile_build = dandischema/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix =
 
 [codespell]


### PR DESCRIPTION
See https://github.com/dandi/dandischema/issues/2#issuecomment-848900472.

In addition to this PR, the tag for at least the most recent library release (0.2.0) must be renamed to have a `v` prefix, and the corresponding GitHub release must be updated to match.