### PR TITLE
fix: dandi-etag carries extra component beyond md5

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -937,7 +937,8 @@ class BareAsset(CommonModel):
     @validator("digest")
     def digest_etag(cls, values):
         try:
-            if len(values[DigestType.dandi_etag]) != 32:
+            digest = values[DigestType.dandi_etag]
+            if "-" not in digest or len(digest.split("-")[0]) != 32:
                 raise ValueError
         except KeyError:
             raise ValueError("Digest is missing dandi-etag value.")
@@ -988,10 +989,14 @@ class PublishedAsset(Asset, Publishable):
     @validator("digest")
     def digest_bothhashes(cls, values):
         try:
-            if len(values[DigestType.dandi_etag] + values[DigestType.sha2_256]) != 96:
-                raise ValueError
-        except (KeyError, ValueError):
-            raise ValueError("Digest must have both valid dandi-etag and sha2-256.")
+            digest = values[DigestType.dandi_etag]
+            if "-" not in digest or len(digest.split("-")[0]) != 32:
+                raise ValueError("Digest is missing dandi-etag value")
+            digest = values[DigestType.sha2_256]
+            if len(digest) != 64:
+                raise ValueError("Digest is missing sha2_256 value")
+        except KeyError:
+            raise ValueError("Digest is missing dandi-etag or sha256 keys.")
         return values
 
 

--- a/dandischema/tests/data/metadata/asset_001.json
+++ b/dandischema/tests/data/metadata/asset_001.json
@@ -33,7 +33,7 @@
   "contentSize": 69105,
   "encodingFormat": "application/x-nwb",
   "digest": {
-    "dandi:sha1": "783ad2afe455839e5ab2fa659861f58a423fd17f"
+    "dandi:dandi-etag": "783ad2afe455839e5ab2fa659861f58a-1"
   },
   "wasDerivedFrom": [
     {

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -30,6 +30,7 @@ def test_asset(schema_dir):
     # under assumption that the 0.3.2 schema would be forward compatible
     data_as_dict["schemaVersion"] = DANDI_SCHEMA_VERSION
     _validate_asset_json(data_as_dict, schema_dir)
+    validate(data_as_dict)
 
 
 def test_dandiset(schema_dir):
@@ -147,7 +148,7 @@ def test_pydantic_validation(schema_dir):
         (
             {
                 "schemaKey": "Asset",
-                "digest": {"dandi:dandi-etag": md5(b"test").hexdigest()},
+                "digest": {"dandi:dandi-etag": md5(b"test").hexdigest() + "-1"},
             },
             None,
             {"contentSize", "encodingFormat", "id", "identifier", "path"},
@@ -186,7 +187,7 @@ def test_pydantic_validation(schema_dir):
         (
             {
                 "schemaKey": "Asset",
-                "digest": {"dandi:dandi-etag": md5(b"test").hexdigest()},
+                "digest": {"dandi:dandi-etag": md5(b"test").hexdigest() + "-1"},
             },
             "PublishedAsset",
             {
@@ -204,7 +205,7 @@ def test_pydantic_validation(schema_dir):
             {
                 "schemaKey": "Asset",
                 "digest": {
-                    "dandi:dandi-etag": md5(b"test").hexdigest(),
+                    "dandi:dandi-etag": md5(b"test").hexdigest() + "-1",
                     "dandi:sha2-256": sha256(b"test").hexdigest(),
                 },
             },

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -29,8 +29,6 @@ def test_asset():
 
 
 def test_asset_digest():
-    from dandischema import migrate, models
-
     digest_model = {"sha1": ""}
     with pytest.raises(pydantic.ValidationError) as exc:
         models.BareAsset(


### PR DESCRIPTION
The check for digest assumed an md5sum. however, the digest has an extra component and are of the form: `<md5sum>-<chunks>`