### PR TITLE
fix: update migration code to account for missing fields

### DIFF
--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -76,15 +76,21 @@ def publish_model_schemata(releasedir: str) -> Path:
     version = models.get_schema_version()
     vdir = Path(releasedir, version)
     vdir.mkdir(exist_ok=True, parents=True)
-    (vdir / "dandiset.json").write_text(models.Dandiset.schema_json(indent=2))
-    (vdir / "asset.json").write_text(models.Asset.schema_json(indent=2))
+    (vdir / "dandiset.json").write_text(
+        models.Dandiset.schema_json(indent=2).rstrip("\n") + "\n"
+    )
+    (vdir / "asset.json").write_text(
+        models.Asset.schema_json(indent=2).rstrip("\n") + "\n"
+    )
     (vdir / "published-dandiset.json").write_text(
-        models.PublishedDandiset.schema_json(indent=2)
+        models.PublishedDandiset.schema_json(indent=2).rstrip("\n") + "\n"
     )
     (vdir / "published-asset.json").write_text(
-        models.PublishedAsset.schema_json(indent=2)
+        models.PublishedAsset.schema_json(indent=2).rstrip("\n") + "\n"
     )
-    (vdir / "context.json").write_text(json.dumps(generate_context(), indent=2))
+    (vdir / "context.json").write_text(
+        json.dumps(generate_context(), indent=2).rstrip("\n") + "\n"
+    )
     return vdir
 
 

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -165,11 +165,10 @@ def migrate(
         if not id.startswith("DANDI:"):
             obj["id"] = f'DANDI:{obj["id"]}'
         for contrib in obj.get("contributor", []):
-            if not contrib.get("roleName"):
-                continue
-            contrib["roleName"] = [
-                val.replace("dandi:", "dcite:") for val in contrib["roleName"]
-            ]
+            if contrib.get("roleName"):
+                contrib["roleName"] = [
+                    val.replace("dandi:", "dcite:") for val in contrib["roleName"]
+                ]
             for affiliation in contrib.get("affiliation", []):
                 affiliation["schemaKey"] = "Affiliation"
         for contrib in obj.get("relatedResource", []):

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -7,7 +7,7 @@ import requests
 
 from .consts import ALLOWED_INPUT_SCHEMAS, ALLOWED_TARGET_SCHEMAS, DANDI_SCHEMA_VERSION
 from . import models
-from .utils import version2tuple
+from .utils import _ensure_newline, version2tuple
 
 
 def generate_context():
@@ -77,19 +77,19 @@ def publish_model_schemata(releasedir: str) -> Path:
     vdir = Path(releasedir, version)
     vdir.mkdir(exist_ok=True, parents=True)
     (vdir / "dandiset.json").write_text(
-        models.Dandiset.schema_json(indent=2).rstrip("\n") + "\n"
+        _ensure_newline(models.Dandiset.schema_json(indent=2))
     )
     (vdir / "asset.json").write_text(
-        models.Asset.schema_json(indent=2).rstrip("\n") + "\n"
+        _ensure_newline(models.Asset.schema_json(indent=2))
     )
     (vdir / "published-dandiset.json").write_text(
-        models.PublishedDandiset.schema_json(indent=2).rstrip("\n") + "\n"
+        _ensure_newline(models.PublishedDandiset.schema_json(indent=2))
     )
     (vdir / "published-asset.json").write_text(
-        models.PublishedAsset.schema_json(indent=2).rstrip("\n") + "\n"
+        _ensure_newline(models.PublishedAsset.schema_json(indent=2))
     )
     (vdir / "context.json").write_text(
-        json.dumps(generate_context(), indent=2).rstrip("\n") + "\n"
+        _ensure_newline(json.dumps(generate_context(), indent=2))
     )
     return vdir
 
@@ -173,10 +173,11 @@ def migrate(
                 affiliation["schemaKey"] = "Affiliation"
         for contrib in obj.get("relatedResource", []):
             contrib["relation"] = contrib["relation"].replace("dandi:", "dcite:")
-        for access in obj.get("access", []):
-            access["status"] = "dandi:OpenAccess"
-        else:
+        if "access" not in obj:
             obj["access"] = [{"status": "dandi:OpenAccess"}]
+        else:
+            for access in obj.get("access", []):
+                access["status"] = "dandi:OpenAccess"
         if obj.get("assetsSummary") is None:
             obj["assetsSummary"] = {"numberOfFiles": 0, "numberOfBytes": 0}
         if obj.get("manifestLocation") is None:

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -158,16 +158,20 @@ def migrate(
         id = obj.get("id")
         if not id.startswith("DANDI:"):
             obj["id"] = f'DANDI:{obj["id"]}'
-        for contrib in obj["contributor"]:
+        for contrib in obj.get("contributor", []):
+            if not contrib.get("roleName"):
+                continue
             contrib["roleName"] = [
                 val.replace("dandi:", "dcite:") for val in contrib["roleName"]
             ]
             for affiliation in contrib.get("affiliation", []):
                 affiliation["schemaKey"] = "Affiliation"
-        for contrib in obj["relatedResource"]:
+        for contrib in obj.get("relatedResource", []):
             contrib["relation"] = contrib["relation"].replace("dandi:", "dcite:")
-        for access in obj["access"]:
+        for access in obj.get("access", []):
             access["status"] = "dandi:OpenAccess"
+        else:
+            obj["access"] = [{"status": "dandi:OpenAccess"}]
         if obj.get("assetsSummary") is None:
             obj["assetsSummary"] = {"numberOfFiles": 0, "numberOfBytes": 0}
         if obj.get("manifestLocation") is None:

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -242,7 +242,7 @@ def test_migrate_errors(obj, target):
         migrate(obj, to_version=target, skip_validation=True)
 
 
-def test_migrate_040(schema_dir):
+def test_migrate_041(schema_dir):
     with (METADATA_DIR / "meta_000004old.json").open() as fp:
         data_as_dict = json.load(fp)
     with pytest.raises(ValueError) as exc:
@@ -266,3 +266,13 @@ def test_migrate_040(schema_dir):
     newmeta["assetsSummary"] = {"numberOfFiles": 1, "numberOfBytes": 1}
     newmeta["manifestLocation"] = ["https://example.org/manifest"]
     _validate_dandiset_json(newmeta, schema_dir)
+
+
+def test_migrate_041_access(schema_dir):
+    with (METADATA_DIR / "meta_000004old.json").open() as fp:
+        data_as_dict = json.load(fp)
+    del data_as_dict["access"]
+    newmeta = migrate(
+        data_as_dict, to_version=DANDI_SCHEMA_VERSION, skip_validation=True
+    )
+    assert newmeta["access"] == [{"status": "dandi:OpenAccess"}]

--- a/dandischema/tests/test_utils.py
+++ b/dandischema/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..utils import name2title, version2tuple
+from ..utils import _ensure_newline, name2title, version2tuple
 
 
 @pytest.mark.parametrize(
@@ -39,3 +39,10 @@ def test_version(ver, error):
             version2tuple(ver)
     else:
         assert len(version2tuple(ver)) == 3
+
+
+def test_newline():
+    obj = "\n"
+    assert _ensure_newline(obj).endswith("\n")
+    obj = ""
+    assert _ensure_newline(obj).endswith("\n")

--- a/dandischema/utils.py
+++ b/dandischema/utils.py
@@ -50,3 +50,9 @@ def version2tuple(ver: str) -> tuple:
     if re.match(r"\d+\.\d+\.\d+$", ver) is None:
         raise ValueError(r"Version must be well formed: \d+\.\d+\.\d+")
     return tuple([int(val) for val in ver.split(".")])
+
+
+def _ensure_newline(obj):
+    if not obj.endswith("\n"):
+        return obj + "\n"
+    return obj


### PR DESCRIPTION
I just ran through all the dandiset metadata and this code wasn't taking badly formed metadata into account.