### PR TITLE
Use DANDI_GITHUB_TOKEN to check out dandi/schema when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
         with:
           repository: dandi/schema
           path: schema
+          token: ${{ secrets.DANDI_GITHUB_TOKEN }}
 
       - name: Test for unversioned changes
         run: |


### PR DESCRIPTION
Fixes #29.