### PR TITLE
fix: allow migration for versions greater than 0.3.2

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,6 +1,10 @@
 DANDI_SCHEMA_VERSION = "0.4.3"
-ALLOWED_TARGET_SCHEMAS = ["0.4.3"]
 ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2"]
+
+# ATM we allow only for a single target version which is current
+# migrate has a guard now for this since it cannot migrate to anything but current
+# version
+ALLOWED_TARGET_SCHEMAS = [DANDI_SCHEMA_VERSION]
 
 if DANDI_SCHEMA_VERSION not in ALLOWED_INPUT_SCHEMAS:
     ALLOWED_INPUT_SCHEMAS.append(DANDI_SCHEMA_VERSION)

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -169,7 +169,7 @@ def migrate(
             f"master/releases/{schema_version}/dandiset.json"
         ).json()
         jsonschema.validate(obj, schema)
-    if version2tuple(schema_version) < (0, 3, 2):
+    if version2tuple(schema_version) < version2tuple(DANDI_SCHEMA_VERSION):
         if obj.get("schemaKey") is None:
             obj["schemaKey"] = "Dandiset"
         id = str(obj.get("id"))

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -154,6 +154,10 @@ def migrate(
 ) -> dict:
     """Migrate dandiset metadata object to new schema"""
     obj = deepcopy(obj)
+    if len(ALLOWED_TARGET_SCHEMAS) > 1:
+        raise NotImplementedError(
+            "ATM code below supports migration to current version only"
+        )
     if to_version not in ALLOWED_TARGET_SCHEMAS:
         raise ValueError(f"Current target schemas: {ALLOWED_TARGET_SCHEMAS}.")
     schema_version = obj.get("schemaVersion")


### PR DESCRIPTION
Allow migrating from versions greater 0.3.1