### PR TITLE
Fix: Make the library more robust for publishing

### DIFF
--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -90,7 +90,7 @@ def to_datacite(
         "resourceTypeGeneral": "Dataset",
     }
     # meta has also attribute url, but it often empty
-    attributes["url"] = str(meta.url)
+    attributes["url"] = str(meta.url or "")
     # assuming that all licenses are from SPDX?
     attributes["rightsList"] = [
         {

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -205,7 +205,9 @@ def to_datacite(
 
 def _get_datacite_schema():
     sr = requests.get(
-        "https://raw.githubusercontent.com/datacite/schema/732cc7ef29f4cad4d6adfac83544133cd57a2e5e/source/json/kernel-4.3/datacite_4.3_schema.json"
+        "https://raw.githubusercontent.com/datacite/schema/"
+        "732cc7ef29f4cad4d6adfac83544133cd57a2e5e/"
+        "source/json/kernel-4.3/datacite_4.3_schema.json"
     )
     sr.raise_for_status()
     schema = sr.json()

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 import re
 import typing as ty
 
-from jsonschema import Draft6Validator
+from jsonschema import Draft7Validator
 import requests
 
 from .models import NAME_PATTERN, Organization, Person, PublishedDandiset, RoleType
@@ -205,8 +205,7 @@ def to_datacite(
 
 def _get_datacite_schema():
     sr = requests.get(
-        "https://raw.githubusercontent.com/datacite/schema/master/source/"
-        "json/kernel-4.3/datacite_4.3_schema.json"
+        "https://raw.githubusercontent.com/datacite/schema/732cc7ef29f4cad4d6adfac83544133cd57a2e5e/source/json/kernel-4.3/datacite_4.3_schema.json"
     )
     sr.raise_for_status()
     schema = sr.json()
@@ -215,6 +214,6 @@ def _get_datacite_schema():
 
 def validate_datacite(datacite_dict):
     schema = _get_datacite_schema()
-    Draft6Validator.check_schema(schema)
-    validator = Draft6Validator(schema)
+    Draft7Validator.check_schema(schema)
+    validator = Draft7Validator(schema)
     validator.validate(datacite_dict["data"]["attributes"])

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -72,7 +72,7 @@ def to_datacite(
             "identifierType": "URL",
         },
         {
-            "identifier": f"https://dandiarchive.org/dandiset/{meta.identifier}",
+            "identifier": str(meta.url),
             "identifierType": "URL",
         },
     ]

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -133,6 +133,17 @@ class DandiBaseModel(BaseModel, metaclass=DandiBaseModelMetaclass):
         """
         return json.loads(self.json(exclude_none=True, cls=HandleKeyEnumEncoder))
 
+    @validator("schemaKey", always=True)
+    def ensure_schemakey(cls, val):
+        tempval = val
+        if "Published" in cls.__name__:
+            tempval = "Published" + tempval
+        if tempval != cls.__name__:
+            raise ValueError(
+                f"schemaKey {tempval} does not match classname {cls.__name__}"
+            )
+        return val
+
     @classmethod
     def unvalidated(__pydantic_cls__: Type[BaseModel], **data: Any) -> BaseModel:
         """Allow model to be returned without validation"""

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -138,6 +138,8 @@ class DandiBaseModel(BaseModel, metaclass=DandiBaseModelMetaclass):
         tempval = val
         if "Published" in cls.__name__:
             tempval = "Published" + tempval
+        if "BareAsset" == cls.__name__:
+            tempval = "Bare" + tempval
         if tempval != cls.__name__:
             raise ValueError(
                 f"schemaKey {tempval} does not match classname {cls.__name__}"

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -138,7 +138,7 @@ class DandiBaseModel(BaseModel, metaclass=DandiBaseModelMetaclass):
         tempval = val
         if "Published" in cls.__name__:
             tempval = "Published" + tempval
-        if "BareAsset" == cls.__name__:
+        elif "BareAsset" == cls.__name__:
             tempval = "Bare" + tempval
         if tempval != cls.__name__:
             raise ValueError(

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -8,7 +8,7 @@ from jsonschema import Draft6Validator
 import pytest
 import requests
 
-from ..datacite import to_datacite
+from ..datacite import _get_datacite_schema, to_datacite
 from ..models import LicenseType, PublishedDandiset, RelationType, RoleType
 
 
@@ -45,13 +45,7 @@ def _clean_doi(doi):
 
 @pytest.fixture(scope="module")
 def schema():
-    sr = requests.get(
-        "https://raw.githubusercontent.com/datacite/schema/master/source/"
-        "json/kernel-4.3/datacite_4.3_schema.json"
-    )
-    sr.raise_for_status()
-    schema = sr.json()
-    return schema
+    return _get_datacite_schema()
 
 
 def _basic_publishmeta(dandi_id, version="v.0", prefix="10.80507"):

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -95,11 +95,7 @@ def test_datacite(dandi_id, schema):
     )
     meta = PublishedDandiset(**meta_js)
 
-    datacite = to_datacite(meta=meta)
-
-    Draft6Validator.check_schema(schema)
-    validator = Draft6Validator(schema)
-    validator.validate(datacite["data"]["attributes"])
+    datacite = to_datacite(meta=meta, validate=True)
 
     # trying to post datacite
     datacite_post(datacite, meta.doi)

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import random
 
-from jsonschema import Draft6Validator
+from jsonschema import Draft7Validator
 import pytest
 import requests
 
@@ -267,8 +267,8 @@ def test_dandimeta_datacite(schema, additional_meta, datacite_checks):
 
     # creating and validating datacite objects
     datacite = to_datacite(meta_dict)
-    Draft6Validator.check_schema(schema)
-    validator = Draft6Validator(schema)
+    Draft7Validator.check_schema(schema)
+    validator = Draft7Validator(schema)
     validator.validate(datacite["data"]["attributes"])
 
     # checking some datacite fields

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -9,14 +9,20 @@ from .. import models
 from ..models import (
     AccessType,
     Asset,
+    DandiBaseModel,
     Dandiset,
     DigestType,
     IdentifierType,
     LicenseType,
+    List,
+    Optional,
+    Organization,
     ParticipantRelationType,
+    Person,
     PublishedDandiset,
     RelationType,
     RoleType,
+    Union,
 )
 
 
@@ -373,3 +379,30 @@ def test_duplicate_classes():
             else:
                 qname = f"dandi:{name}"
             check_qname(qname, klass)
+
+
+def test_schemakey_roundtrip():
+    class TempKlass(DandiBaseModel):
+        contributor: Optional[List[Union[Organization, Person]]]
+
+    contributor = [
+        {
+            "name": "first",
+            "roleName": [],
+            "schemaKey": "Person",
+            "affiliation": [],
+            "includeInCitation": True,
+        },
+        {
+            "name": "last2, first2",
+            "roleName": ["dcite:ContactPerson"],
+            "schemaKey": "Person",
+            "affiliation": [],
+            "includeInCitation": True,
+        },
+    ]
+    with pytest.raises(pydantic.ValidationError):
+        TempKlass(contributor=contributor)
+    contributor[0]["name"] = "last, first"
+    klassobj = TempKlass(contributor=contributor)
+    assert all([isinstance(val, Person) for val in klassobj.contributor])


### PR DESCRIPTION
1. updates datacite constructor to ensure
  - contributorType
  - support validation against jsonschema from datacite (this may not be authoritative and should be used with care)
2. ensure that round tripping of schemaKey creates the same object or raises a validation error

closes https://github.com/dandi/dandi-api/issues/347