### PR TITLE
enh: update models to do more validation checks

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,5 +1,5 @@
-DANDI_SCHEMA_VERSION = "0.4.3"
-ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2"]
+DANDI_SCHEMA_VERSION = "0.4.4"
+ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2", "0.4.3"]
 
 # ATM we allow only for a single target version which is current
 # migrate has a guard now for this since it cannot migrate to anything but current

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -43,6 +43,12 @@ if "DANDI_ALLOW_LOCALHOST_URLS" in os.environ:
 
 
 NAME_PATTERN = r"^([\w\s\-]+)?,\s+([\w\s\-\.]+)?$"
+ASSET_UUID_PATTERN = (
+    r"^dandiasset:[a-f0-9]{8}[-]*[a-f0-9]{4}[-]*"
+    "[a-f0-9]{4}[-]*[a-f0-9]{4}[-]*[a-f0-9]{12}$"
+)
+DANDI_DOI_PATTERN = r"^10.80507/dandi\.\d{6}/\d+\.\d+\.\d+"
+DANDI_PUBID_PATTERN = r"^DANDI:\d{6}/\d+\.\d+\.\d+"
 
 
 def create_enum(data):
@@ -252,6 +258,7 @@ ORCID = str
 RORID = str
 DANDI = str
 RRID = str
+DANDIURL = str
 
 
 class BaseType(DandiBaseModel):
@@ -1010,14 +1017,23 @@ class Publishable(DandiBaseModel):
 
 
 class PublishedDandiset(Dandiset, Publishable):
+    id: str = Field(
+        description="Uniform resource identifier",
+        regex=DANDI_PUBID_PATTERN,
+        readOnly=True,
+    )
+
     doi: str = Field(
         title="DOI",
         readOnly=True,
-        regex=r"^10\.[A-Za-z0-9\.\/-]+",
+        regex=DANDI_DOI_PATTERN,
         nskey="dandi",
     )
-    url: HttpUrl = Field(
-        readOnly=True, description="permalink to the item", nskey="schema"
+    url: DANDIURL = Field(
+        readOnly=True,
+        description="permalink to the item",
+        regex=r"^https://dandiarchive.org/dandiset/\d{6}/\d+\.\d+\.\d+$",
+        nskey="schema",
     )
 
     schemaKey = "Dandiset"
@@ -1032,6 +1048,12 @@ class PublishedDandiset(Dandiset, Publishable):
 
 
 class PublishedAsset(Asset, Publishable):
+
+    id: str = Field(
+        description="Uniform resource identifier",
+        regex=ASSET_UUID_PATTERN,
+        readOnly=True,
+    )
 
     schemaKey = "Asset"
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -43,10 +43,11 @@ if "DANDI_ALLOW_LOCALHOST_URLS" in os.environ:
 
 
 NAME_PATTERN = r"^([\w\s\-]+)?,\s+([\w\s\-\.]+)?$"
-ASSET_UUID_PATTERN = (
-    r"^dandiasset:[a-f0-9]{8}[-]*[a-f0-9]{4}[-]*"
+UUID_PATTERN = (
+    "[a-f0-9]{8}[-]*[a-f0-9]{4}[-]*"
     "[a-f0-9]{4}[-]*[a-f0-9]{4}[-]*[a-f0-9]{12}$"
 )
+ASSET_UUID_PATTERN = r"^dandiasset:" + UUID_PATTERN
 DANDI_DOI_PATTERN = r"^10.80507/dandi\.\d{6}/\d+\.\d+\.\d+"
 DANDI_PUBID_PATTERN = r"^DANDI:\d{6}/\d+\.\d+\.\d+"
 
@@ -1031,7 +1032,7 @@ class PublishedDandiset(Dandiset, Publishable):
     )
     url: DANDIURL = Field(
         readOnly=True,
-        description="permalink to the item",
+        description="permalink to the dandiset",
         regex=r"^https://dandiarchive.org/dandiset/\d{6}/\d+\.\d+\.\d+$",
         nskey="schema",
     )

--- a/dandischema/tests/data/metadata/meta_000004.json
+++ b/dandischema/tests/data/metadata/meta_000004.json
@@ -373,7 +373,7 @@
       "status": "dandi:OpenAccess"
     }
   ],
-  "url": "https://dandiarchive.org/000004/draft",
+  "url": "https://dandiarchive.org/dandiset/000004/draft",
   "repository": "https://dandiarchive.org/",
   "relatedResource": [
     {

--- a/dandischema/tests/data/metadata/meta_000004old.json
+++ b/dandischema/tests/data/metadata/meta_000004old.json
@@ -1,6 +1,6 @@
 {
   "id": "000004/draft",
-  "url": "https://dandiarchive.org/000004/draft",
+  "url": "https://dandiarchive.org/dandiset/000004/draft",
   "name": "A NWB-based dataset and processing pipeline of human single-neuron activity during a declarative memory task",
   "about": [
     {

--- a/dandischema/tests/data/metadata/meta_000008.json
+++ b/dandischema/tests/data/metadata/meta_000008.json
@@ -166,7 +166,7 @@
       "status": "dandi:OpenAccess"
     }
   ],
-  "url": "https://dandiarchive.org/000008/draft",
+  "url": "https://dandiarchive.org/dandiset/000008/draft",
   "repository": "https://dandiarchive.org/",
   "relatedResource": [
     {

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -241,7 +241,7 @@ def test_dantimeta_1():
     meta_dict = {
         "identifier": "DANDI:999999",
         "id": "DANDI:999999/draft",
-        "version": "v.1",
+        "version": "1.0.0",
         "name": "testing dataset",
         "description": "testing",
         "contributor": [
@@ -274,6 +274,9 @@ def test_dantimeta_1():
     error_msgs = [
         "field required",
         "A Dandiset containing no files or zero bytes is not publishable",
+        'string does not match regex "^https://dandiarchive.org/dandiset/'
+        '\\d{6}/\\d+\\.\\d+\\.\\d+$"',
+        'string does not match regex "^DANDI:\\d{6}/\\d+\\.\\d+\\.\\d+"',
     ]
     assert all([el["msg"] in error_msgs for el in exc.value.errors()])
     assert set([el["loc"][0] for el in exc.value.errors()]) == {
@@ -281,11 +284,16 @@ def test_dantimeta_1():
         "datePublished",
         "publishedBy",
         "doi",
+        "url",
+        "id",
     }
 
     # after adding basic meta required to publish: doi, datePublished, publishedBy, assetsSummary,
     # so PublishedDandiset should work
-    meta_dict.update(_basic_publishmeta(dandi_id="DANDI:999999"))
+    meta_dict["url"] = "https://dandiarchive.org/dandiset/999999/0.0.0"
+    meta_dict["id"] = "DANDI:999999/0.0.0"
+    meta_dict["version"] = "0.0.0"
+    meta_dict.update(_basic_publishmeta(dandi_id="999999"))
     meta_dict["assetsSummary"].update(**{"numberOfBytes": 1, "numberOfFiles": 1})
     PublishedDandiset(**meta_dict)
 


### PR DESCRIPTION
This improves a bunch of validation specs for publish.  However, the current implementation is completely predicated on production servers and prefixes. 

Calling this a draft for now while we think about how to get info about the domain in which the schema is running. technically for most users everything should validate against the production sites. but devs may need other things.