### PR TITLE
enh: allow checking to see data are matched but allow for missing fields

### DIFF
--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -158,12 +158,12 @@ def validate(obj, schema_version=None, schema_key=None, missing_ok=False):
             raise
         reraise = False
         messages = []
-        for el in exc.value.errors():
+        for el in exc.errors():
             if el["msg"] != "field required":
                 reraise = True
                 messages.append(el["msg"])
         if reraise:
-            raise ValueError(messages)
+            ValueError(messages)
 
 
 def migrate(

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -121,7 +121,9 @@ def validate(obj, schema_version=None, schema_key=None, for_post=False):
       Name of the schema key to be used, if not specified, `schemaKey` of the
       object will be consulted
     for_post: bool, optional
-      Checks if the metadata is suitable for posting to the api server
+      Checks if the metadata is suitable for posting to the api server. If fails validation,
+      but ValidationError only includes "field required" errors, a `ValueError` is raised with
+      the list of all errors.
 
      Returns
      -------

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -232,6 +232,30 @@ def test_requirements(obj, schema_key, missingfields):
 
 
 @pytest.mark.parametrize(
+    "obj, schema_key, errors",
+    [
+        (
+            {"schemaKey": "Dandiset"},
+            None,
+            {"field required"},
+        ),
+        (
+            {"schemaKey": "Dandiset", "identifier": "000000"},
+            None,
+            {'string does not match regex "^DANDI\\:\\d{6}$"', "field required"},
+        ),
+    ],
+)
+def test_missing_ok(obj, schema_key, errors):
+    validate(
+        obj, schema_key=schema_key, schema_version=DANDI_SCHEMA_VERSION, missing_ok=True
+    )
+    with pytest.raises(ValueError) as exc:
+        validate(obj, schema_key=schema_key, schema_version=DANDI_SCHEMA_VERSION)
+    assert set([el["msg"] for el in exc.value.errors()]) == errors
+
+
+@pytest.mark.parametrize(
     "obj, target",
     [
         ({}, "0.3.2"),


### PR DESCRIPTION
adding a mechanism to allow checking that a metadata blob for dandiset or asset has proper values given the schema, but may have missing fields. these metadata objects should be ok for posting but not for publishing.

@dchiquito and @jwodder - would this be useful?