### PR TITLE
RF(CI): run dandi-cli tests only against 3.8 (but all OSes)

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -21,9 +21,10 @@ jobs:
           - ubuntu-18.04
           - macos-latest
         python:
-          - 3.7
+          # Use the only Python which is ATM also used by dandi-api
+          # - 3.7
           - 3.8
-          - 3.9
+          # - 3.9
         version:
           - master
           - release
@@ -31,11 +32,11 @@ jobs:
           - normal
         include:
           - os: ubuntu-18.04
-            python: 3.7
+            python: 3.8
             mode: dandi-devel
             version: master
           - os: ubuntu-18.04
-            python: 3.7
+            python: 3.8
             mode: dandi-devel
             version: release
         exclude:


### PR DESCRIPTION
ATM we really overwhelm dandischema PRs with reports from dandi-cli.
I think it will be sufficient to just test against a single python version
at least for now