### PR TITLE
add AssetSummary.dataStandard namespace

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -620,7 +620,7 @@ class AssetsSummary(DandiBaseModel):
     numberOfSamples: Optional[int] = Field(None, readOnly=True)  # more of NWB
     numberOfCells: Optional[int] = Field(None, readOnly=True)
 
-    dataStandard: Optional[List[StandardsType]] = Field(readOnly=True)
+    dataStandard: Optional[List[StandardsType]] = Field(readOnly=True, nskey="dandi")
     # Web UI: icons per each modality?
     approach: Optional[List[ApproachType]] = Field(readOnly=True)
     # Web UI: could be an icon with number, which if hovered on  show a list?


### PR DESCRIPTION
the assetsummary `dataStandard` attribute didn't have the `nskey` set and was therefore not included in the generated JSONLD context. 
- add nskey
- give dandi namespace for JSONLD context generation