### PR TITLE
handling schemaKey

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,5 +1,14 @@
-DANDI_SCHEMA_VERSION = "0.5.1"
-ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2", "0.4.3", "0.4.4"]
+DANDI_SCHEMA_VERSION = "0.6.0"
+ALLOWED_INPUT_SCHEMAS = [
+    "0.3.0",
+    "0.3.1",
+    "0.4.0",
+    "0.4.1",
+    "0.4.2",
+    "0.4.3",
+    "0.4.4",
+    "0.5.1",
+]
 
 # ATM we allow only for a single target version which is current
 # migrate has a guard now for this since it cannot migrate to anything but current
@@ -7,7 +16,7 @@ ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2", "0.4.3", "
 ALLOWED_TARGET_SCHEMAS = [DANDI_SCHEMA_VERSION]
 # This allows multiple schemas for validation, whereas target schemas focus on
 # migration.
-ALLOWED_VALIDATION_SCHEMAS = ALLOWED_TARGET_SCHEMAS + ["0.4.4"]
+ALLOWED_VALIDATION_SCHEMAS = ALLOWED_TARGET_SCHEMAS + ["0.4.4", "0.5.1"]
 
 if DANDI_SCHEMA_VERSION not in ALLOWED_INPUT_SCHEMAS:
     ALLOWED_INPUT_SCHEMAS.append(DANDI_SCHEMA_VERSION)

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -195,7 +195,7 @@ def migrate(
             f"master/releases/{schema_version}/dandiset.json"
         ).json()
         jsonschema.validate(obj, schema)
-    if version2tuple(schema_version) < version2tuple(DANDI_SCHEMA_VERSION):
+    if version2tuple(schema_version) < version2tuple("0.4.0"):
         if obj.get("schemaKey") is None:
             obj["schemaKey"] = "Dandiset"
         id = str(obj.get("id"))
@@ -219,6 +219,13 @@ def migrate(
             obj["assetsSummary"] = {"numberOfFiles": 0, "numberOfBytes": 0}
         if obj.get("manifestLocation") is None:
             obj["manifestLocation"] = []
+    if version2tuple(schema_version) < version2tuple(DANDI_SCHEMA_VERSION):
+        for val in obj.get("about", []):
+            if "schemaKey" not in val:
+                val["schemaKey"] = "GenericType"
+        for val in obj.get("access", []):
+            if "schemaKey" not in val:
+                val["schemaKey"] = "AccessRequirements"
         obj["schemaVersion"] = to_version
     return obj
 

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -16,6 +16,7 @@ from ..models import (
     DandiBaseModel,
     Dandiset,
     DigestType,
+    Disorder,
     IdentifierType,
     LicenseType,
     List,
@@ -448,3 +449,20 @@ def test_https_regex():
     props = json.loads(Affiliation.schema_json())["properties"]["identifier"]
     assert props["format"] == "uri"
     assert props.get("maxLength") == 1000
+
+
+def test_schemakey_in_required():
+    props = json.loads(Affiliation.schema_json())["properties"]["required"]
+    assert "schemaKey" in props
+
+
+def test_missing_schemakey():
+    with pytest.raises(pydantic.ValidationError) as exc:
+        Disorder()
+    assert any(
+        [
+            "MissingSchemaKey does not match classname Disorder" in val
+            for val in set([el["msg"] for el in exc.value.errors()])
+        ]
+    )
+    Disorder(schemaKey="Disorder")


### PR DESCRIPTION
@yarikoptic - this is an initial attempt to handle `schemaKey`, but this requires a weird thing from a python perspective.

in pydantic, a class is initialized with `kwargs`. this PR adds `schemaKey` to `kwargs` to get the validator to trigger a mismatch. this works for passing data from an existing document. however, this also means that any initialization of the class will also require the appropriate `schemaKey`. see the `test_missing_schemakey` in the PR. this is quite weird.

the alternative is a function that checks every object (i.e. dictionary) in a json record for the presence of `schemaKey`, but then this function would need to be called before initializing the class, which also seems weird.

things addressed
- [X] adding schemaKey as a requirement to JSON schema
