### PR TITLE
remove NC license

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,5 +1,14 @@
-DANDI_SCHEMA_VERSION = "0.5.1"
-ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2", "0.4.3", "0.4.4"]
+DANDI_SCHEMA_VERSION = "0.5.2"
+ALLOWED_INPUT_SCHEMAS = [
+    "0.3.0",
+    "0.3.1",
+    "0.4.0",
+    "0.4.1",
+    "0.4.2",
+    "0.4.3",
+    "0.4.4",
+    "0.5.1",
+]
 
 # ATM we allow only for a single target version which is current
 # migrate has a guard now for this since it cannot migrate to anything but current

--- a/dandischema/model_types.py
+++ b/dandischema/model_types.py
@@ -144,12 +144,6 @@ LicenseTypeDict = {
             "@type": "dandi:LicenseType",
             "rdfs:label": "Attribution 4.0 International (CC BY 4.0)",
         },
-        {
-            "@id": "spdx:CC-BY-NC-4.0",
-            "rdfs:seeAlso": "https://creativecommons.org/licenses/by-nc/4.0/legalcode",
-            "@type": "dandi:LicenseType",
-            "rdfs:label": "Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
-        },
     ]
 }
 

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -202,7 +202,6 @@ def test_asset_digest():
             {
                 "CC0_10": "spdx:CC0-1.0",
                 "CC_BY_40": "spdx:CC-BY-4.0",
-                "CC_BY_NC_40": "spdx:CC-BY-NC-4.0",
             },
         ),
         (


### PR DESCRIPTION
this should remove NC license, which should not allow validation for any dandiset still remaining with the license. this updates the schema version as well.