### PR TITLE
Handle undefined identifier in asset aggregation

### DIFF
--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -291,8 +291,9 @@ def _add_asset_to_stats(assetmeta: Dict[str, Any], stats: _stats_type) -> None:
             if "species" in value:
                 if value["species"] not in stats["species"]:
                     stats["species"].append(value["species"])
-            if value["identifier"] not in stats["subjects"]:
-                stats["subjects"].append(value["identifier"])
+            if "identifier" in value:
+                if value["identifier"] not in stats["subjects"]:
+                    stats["subjects"].append(value["identifier"])
 
     hierarchy = ["cell", "slice", "tissuesample"]
     for val in hierarchy:


### PR DESCRIPTION
This bug caused an issue while migrating dandiset 000025 in production. While trying to save the migrated dandiset, this error ocurred:
```
Migrating 000025/draft
[17:11:02] ERROR    Error calculating assetsSummary
                    Traceback (most recent call last):                                                                                                                                 
                      File "/app/dandiapi/api/models/version.py", line 228, in _populate_metadata                                                                                      
                        summary = aggregate_assets_summary(                                                                                                                            
                      File "/app/.heroku/python/lib/python3.8/site-packages/dandischema/metadata.py", line 321, in aggregate_assets_summary                                            
                        _add_asset_to_stats(meta, stats)                                                                                                                               
                      File "/app/.heroku/python/lib/python3.8/site-packages/dandischema/metadata.py", line 294, in _add_asset_to_stats                                                 
                        if value["identifier"] not in stats["subjects"]:                                                                                                               
                    KeyError: 'identifier'                                                                                                                                             
```

Apparently some asset does not have an `identifier` defined, which the code expected.