### PR TITLE
fix: associate schema key with schemas for older versions

### DIFF
--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -177,7 +177,6 @@ def validate(
             f"Allowed are: {', '.join(ALLOWED_VALIDATION_SCHEMAS)}."
         )
     if json_validation:
-        print(schema_version, DANDI_SCHEMA_VERSION)
         if schema_version == DANDI_SCHEMA_VERSION:
             klass = getattr(models, schema_key)
             schema = klass.schema()

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -177,13 +177,26 @@ def validate(
             f"Allowed are: {', '.join(ALLOWED_VALIDATION_SCHEMAS)}."
         )
     if json_validation:
+        print(schema_version, DANDI_SCHEMA_VERSION)
         if schema_version == DANDI_SCHEMA_VERSION:
             klass = getattr(models, schema_key)
             schema = klass.schema()
         else:
+            schema_map = {
+                "Dandiset": "dandiset",
+                "PublishedDandiset": "published-dandiset",
+                "Asset": "asset",
+                "PublishedAsset": "published-asset",
+            }
+            if schema_key not in schema_map:
+                raise ValueError(
+                    "Only dandisets and assets can be validated "
+                    "using json schema for older versions"
+                )
+            schema_name = schema_map[schema_key]
             schema = requests.get(
                 f"https://raw.githubusercontent.com/dandi/schema/"
-                f"master/releases/{schema_version}/dandiset.json"
+                f"master/releases/{schema_version}/{schema_name}.json"
             ).json()
         _validate_obj_json(obj, schema, missing_ok)
     klass = getattr(models, schema_key)

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -165,12 +165,7 @@ def validate(
     if schema_key is None:
         raise ValueError("Provided object has no known schemaKey")
     schema_version = schema_version or obj.get("schemaVersion")
-    if schema_version not in ALLOWED_VALIDATION_SCHEMAS and schema_key in [
-        "Dandiset",
-        "PublishedDandiset",
-        "Asset",
-        "PublishedAsset",
-    ]:
+    if schema_version not in ALLOWED_VALIDATION_SCHEMAS and schema_key in schema_map:
         raise ValueError(
             f"Metadata version {schema_version} is not allowed. "
             f"Allowed are: {', '.join(ALLOWED_VALIDATION_SCHEMAS)}."

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -507,3 +507,17 @@ def test_aggregate_nonsupported(version):
     assert "Allowed are" in str(exc)
     assert DANDI_SCHEMA_VERSION in str(exc)
     assert version in str(exc)
+
+
+def test_validate_older():
+    with pytest.raises(ValueError):
+        validate(
+            {"schemaVersion": "0.5.2", "schemaKey": "Anykey"}, json_validation=True
+        )
+    with pytest.raises(JsonschemaValidationError):
+        validate({"schemaVersion": "0.5.2", "schemaKey": "Asset"}, json_validation=True)
+    with pytest.raises(JsonschemaValidationError):
+        validate(
+            {"schemaVersion": DANDI_SCHEMA_VERSION, "schemaKey": "Asset"},
+            json_validation=True,
+        )

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -509,6 +509,7 @@ def test_aggregate_nonsupported(version):
     assert version in str(exc)
 
 
+@skipif_no_network
 def test_validate_older():
     with pytest.raises(ValueError):
         validate(


### PR DESCRIPTION
this fixes that only dandiset.json was being used for json validation when schema version of the object did not match current schema.