### PR TITLE
Update codecov action to v2

### DIFF
--- a/.github/workflows/test-nonetwork.yml
+++ b/.github/workflows/test-nonetwork.yml
@@ -46,7 +46,7 @@ jobs:
           DANDI_TESTS_NONETWORK: 1
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       run: tox -e py -- -s --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
Version 1 of codecov's GitHub action is [deprecated](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1) and will start experiencing brownouts soon, and they advise updating to v2.