### PR TITLE
Modify `PublishedDandiset` `url` regex to allow any URL

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1151,7 +1151,7 @@ class PublishedDandiset(Dandiset, Publishable):
     url: DANDIURL = Field(
         readOnly=True,
         description="Permalink to the Dandiset.",
-        regex=r"^https://dandiarchive.org/dandiset/\d{6}/\d+\.\d+\.\d+$",
+        regex=r"^https?:\/\/\S+\/dandiset\/\d{6}\/\d+\.\d+\.\d+$",
         nskey="schema",
     )
 

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -285,8 +285,8 @@ def test_dantimeta_1():
     error_msgs = [
         "field required",
         "A Dandiset containing no files or zero bytes is not publishable",
-        'string does not match regex "^https://dandiarchive.org/dandiset/'
-        '\\d{6}/\\d+\\.\\d+\\.\\d+$"',
+        'string does not match regex "^https?:\\/\\/\\S+\\/dandiset\\/'
+        '\\d{6}\\/\\d+\\.\\d+\\.\\d+$"',
         'string does not match regex "^DANDI:\\d{6}/\\d+\\.\\d+\\.\\d+"',
     ]
     assert all([el["msg"] in error_msgs for el in exc.value.errors()])


### PR DESCRIPTION
Currently, the `url` permalink of a published dandiset must begin with `https://dandiarchive.org` in order to pass validation. [This dandi-api PR](https://github.com/dandi/dandi-api/pull/613) eliminates the use of that hardcoded URL, so dandisets published in staging or local dev environments will fail validation. 

This PR modifies the regex for the `url` permalink of a published dandiset so that any URL is valid.