### PR TITLE
Remove duplicate "requests" dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ style =
 test =
     pytest
     pytest-cov
-    requests
 all =
     #%(doc)s
     %(style)s


### PR DESCRIPTION
"requests" was declared as both a normal installation requirement and as a member of the "test" extra.  This PR removes the superfluous latter declaration.