### PR TITLE
Update versioningit version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Setuptools version should match setup.py; wheel because pip will insert it noisily
-requires = ["setuptools >= 42.0.0", "versioningit ~= 0.1.0", "wheel"]
+requires = ["setuptools >= 42.0.0", "versioningit ~= 0.3.0", "wheel"]
 build-backend = 'setuptools.build_meta'
 
 [tool.versioningit]

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,5 @@ if sys.version_info < (3,):
         "You are using %s" % sys.version
     )
 
-# Give setuptools a hint to complain if it's too old a version
-# Should match pyproject.toml
-SETUP_REQUIRES = ["setuptools >= 42.0.0", "versioningit ~= 0.1.0"]
-# This enables setuptools to install wheel on-the-fly
-SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
-
 if __name__ == "__main__":
-    setup(name="dandischema", setup_requires=SETUP_REQUIRES)
+    setup(name="dandischema")


### PR DESCRIPTION
This fixes a fatal problem involving a tomli version incompatibility.

This PR also removes the use of `setup_requires`, which is deprecated as of setuptools v58.3.0.