### PR TITLE
fix: address pydantic issue to make value required

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -267,7 +267,7 @@ class PropertyValue(DandiBaseModel):
 
     @validator("value", always=True)
     def ensure_value(cls, val):
-        if val is None or not val:
+        if not val:
             raise ValueError(
                 "The value field of a PropertyValue cannot be None or empty."
             )

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -189,6 +189,8 @@ class DandiBaseModel(BaseModel, metaclass=DandiBaseModelMetaclass):
     class Config:
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model) -> None:
+            if schema["title"] == "PropertyValue":
+                schema["required"] = ["value"] + schema.get("required", [])
             schema["title"] = name2title(schema["title"])
             if schema["type"] == "object":
                 schema["required"] = schema.get("required", []) + ["schemaKey"]
@@ -258,6 +260,14 @@ class PropertyValue(DandiBaseModel):
         "For example, a known prefix like DOI or a full URL.",
         nskey="schema",
     )
+
+    @validator("value", always=True)
+    def ensure_value(cls, val):
+        if val is None or not val:
+            raise ValueError(
+                "The value field of a PropertyValue cannot be None or empty."
+            )
+        return val
 
     _ldmeta = {"nskey": "schema"}
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -190,10 +190,14 @@ class DandiBaseModel(BaseModel, metaclass=DandiBaseModelMetaclass):
         @staticmethod
         def schema_extra(schema: Dict[str, Any], model) -> None:
             if schema["title"] == "PropertyValue":
-                schema["required"] = ["value"] + schema.get("required", [])
+                schema["required"] = list(
+                    set(["value"]).union(schema.get("required", []))
+                )
             schema["title"] = name2title(schema["title"])
             if schema["type"] == "object":
-                schema["required"] = schema.get("required", []) + ["schemaKey"]
+                schema["required"] = list(
+                    set(schema.get("required", [])).union(["schemaKey"])
+                )
             for prop, value in schema.get("properties", {}).items():
                 if schema["title"] == "Person":
                     if prop == "name":

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -23,6 +23,7 @@ from ..models import (
     Organization,
     ParticipantRelationType,
     Person,
+    PropertyValue,
     PublishedDandiset,
     RelationType,
     Resource,
@@ -478,3 +479,20 @@ def test_https_regex():
 def test_schemakey_in_required():
     props = json.loads(Affiliation.schema_json())["required"]
     assert "schemaKey" in props
+
+
+@pytest.mark.parametrize("value", [None, [], {}, (), ""])
+def test_propertyvalue(value):
+    with pytest.raises(pydantic.ValidationError):
+        PropertyValue(value=value)
+
+
+def test_propertyvalue_valid():
+    PropertyValue(value=1)
+
+
+def test_propertyvalue_json():
+    reqprops = json.loads(PropertyValue.schema_json())["definitions"]["PropertyValue"][
+        "required"
+    ]
+    assert "value" in reqprops


### PR DESCRIPTION
pydantic fixed a bug where it rightfully treats `Any` as being equivalent to `Optional`. we were abusing the previous state. This change fixes the schema to be in line with pydantic without a new schema release.

This needs to be merged before #105 