### PR TITLE
Zarr checksum calculation

### DIFF
--- a/dandischema/digests/tests/test_zarr.py
+++ b/dandischema/digests/tests/test_zarr.py
@@ -7,6 +7,7 @@ from dandischema.digests.zarr import (
     ZarrChecksumListing,
     ZarrChecksums,
     ZarrJSONChecksumSerializer,
+    get_checksum,
 )
 
 
@@ -107,3 +108,43 @@ def test_zarr_deserialize():
         ),
         md5="c",
     )
+
+
+@pytest.mark.parametrize(
+    "files,directories,checksum",
+    [
+        ({}, {}, "481a2f77ab786a0f45aafd5db0971caa"),
+        (
+            {"foo/bar": "a"},
+            {},
+            "cdcfdfca3622e20df03219273872549e",
+        ),
+        (
+            {},
+            {"foo/bar": "a"},
+            "243aca82c6872222747183dd738b6fcb",
+        ),
+        (
+            {"foo/bar": "a", "foo/baz": "b"},
+            {},
+            "785295076ae9156b363e442ef6d485e0",
+        ),
+        (
+            {},
+            {"foo/bar": "a", "foo/baz": "b"},
+            "ebca8bb8e716237e0f71657d1045930f",
+        ),
+        (
+            {},
+            {"foo/baz": "b", "foo/bar": "a"},
+            "ebca8bb8e716237e0f71657d1045930f",
+        ),
+        (
+            {"foo/baz": "a"},
+            {"foo/bar": "b"},
+            "9c34644ba03b7e9f58ebd1caef4215ad",
+        ),
+    ],
+)
+def test_zarr_get_checksum(files, directories, checksum):
+    assert get_checksum(files=files, directories=directories) == checksum

--- a/dandischema/digests/tests/test_zarr.py
+++ b/dandischema/digests/tests/test_zarr.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from dandischema.digests.zarr import (
+    ZarrChecksum,
+    ZarrChecksumListing,
+    ZarrChecksums,
+    ZarrJSONChecksumSerializer,
+)
+
+
+def test_zarr_checksum_sort_order():
+    # The a < b in the path should take precedence over z > y in the md5
+    a = ZarrChecksum(path='1/2/3/a/z', md5='z')
+    b = ZarrChecksum(path='1/2/3/b/z', md5='y')
+    assert sorted([b, a]) == [a, b]
+
+
+# ZarrJSONChecksumSerializer tests
+
+
+@pytest.mark.parametrize(
+    'file_checksums,directory_checksums,checksum',
+    [
+        ([], [], '481a2f77ab786a0f45aafd5db0971caa'),
+        ([ZarrChecksum(path='foo/bar', md5='a')], [], 'cdcfdfca3622e20df03219273872549e'),
+        ([], [ZarrChecksum(path='foo/bar', md5='a')], '243aca82c6872222747183dd738b6fcb'),
+        (
+            [ZarrChecksum(path='foo/bar', md5='a'), ZarrChecksum(path='foo/baz', md5='b')],
+            [],
+            '785295076ae9156b363e442ef6d485e0',
+        ),
+        (
+            [],
+            [ZarrChecksum(path='foo/bar', md5='a'), ZarrChecksum(path='foo/baz', md5='b')],
+            'ebca8bb8e716237e0f71657d1045930f',
+        ),
+        (
+            [ZarrChecksum(path='foo/baz', md5='a')],
+            [ZarrChecksum(path='foo/bar', md5='b')],
+            '9c34644ba03b7e9f58ebd1caef4215ad',
+        ),
+    ],
+)
+def test_zarr_checksum_serializer_aggregate_checksum(file_checksums, directory_checksums, checksum):
+    serializer = ZarrJSONChecksumSerializer()
+    assert (
+        serializer.aggregate_checksum(
+            ZarrChecksums(files=file_checksums, directories=directory_checksums)
+        )
+        == checksum
+    )
+
+
+def test_zarr_checksum_serializer_generate_listing():
+    serializer = ZarrJSONChecksumSerializer()
+    checksums = ZarrChecksums(
+        files=[ZarrChecksum(path='foo/bar', md5='a')],
+        directories=[ZarrChecksum(path='foo/baz', md5='b')],
+    )
+    assert serializer.generate_listing(checksums) == ZarrChecksumListing(
+        checksums=checksums, md5='23076057c0da63f8ab50d0a108db332c'
+    )
+
+
+def test_zarr_serialize():
+    serializer = ZarrJSONChecksumSerializer()
+    assert (
+        serializer.serialize(
+            ZarrChecksumListing(
+                checksums=ZarrChecksums(
+                    files=[ZarrChecksum(path='foo/bar', md5='a')],
+                    directories=[ZarrChecksum(path='bar/foo', md5='b')],
+                ),
+                md5='c',
+            )
+        )
+        == '{"checksums":{"directories":[{"md5":"b","path":"bar/foo"}],"files":[{"md5":"a","path":"foo/bar"}]},"md5":"c"}'  # noqa: E501
+    )
+
+
+def test_zarr_deserialize():
+    serializer = ZarrJSONChecksumSerializer()
+    assert serializer.deserialize(
+        '{"checksums":{"directories":[{"md5":"b","path":"bar/foo"}],"files":[{"md5":"a","path":"foo/bar"}]},"md5":"c"}'  # noqa: E501
+    ) == ZarrChecksumListing(
+        checksums=ZarrChecksums(
+            files=[ZarrChecksum(path='foo/bar', md5='a')],
+            directories=[ZarrChecksum(path='bar/foo', md5='b')],
+        ),
+        md5='c',
+    )

--- a/dandischema/digests/tests/test_zarr.py
+++ b/dandischema/digests/tests/test_zarr.py
@@ -12,8 +12,8 @@ from dandischema.digests.zarr import (
 
 def test_zarr_checksum_sort_order():
     # The a < b in the path should take precedence over z > y in the md5
-    a = ZarrChecksum(path='1/2/3/a/z', md5='z')
-    b = ZarrChecksum(path='1/2/3/b/z', md5='y')
+    a = ZarrChecksum(path="1/2/3/a/z", md5="z")
+    b = ZarrChecksum(path="1/2/3/b/z", md5="y")
     assert sorted([b, a]) == [a, b]
 
 
@@ -21,29 +21,45 @@ def test_zarr_checksum_sort_order():
 
 
 @pytest.mark.parametrize(
-    'file_checksums,directory_checksums,checksum',
+    "file_checksums,directory_checksums,checksum",
     [
-        ([], [], '481a2f77ab786a0f45aafd5db0971caa'),
-        ([ZarrChecksum(path='foo/bar', md5='a')], [], 'cdcfdfca3622e20df03219273872549e'),
-        ([], [ZarrChecksum(path='foo/bar', md5='a')], '243aca82c6872222747183dd738b6fcb'),
+        ([], [], "481a2f77ab786a0f45aafd5db0971caa"),
         (
-            [ZarrChecksum(path='foo/bar', md5='a'), ZarrChecksum(path='foo/baz', md5='b')],
+            [ZarrChecksum(path="foo/bar", md5="a")],
             [],
-            '785295076ae9156b363e442ef6d485e0',
+            "cdcfdfca3622e20df03219273872549e",
         ),
         (
             [],
-            [ZarrChecksum(path='foo/bar', md5='a'), ZarrChecksum(path='foo/baz', md5='b')],
-            'ebca8bb8e716237e0f71657d1045930f',
+            [ZarrChecksum(path="foo/bar", md5="a")],
+            "243aca82c6872222747183dd738b6fcb",
         ),
         (
-            [ZarrChecksum(path='foo/baz', md5='a')],
-            [ZarrChecksum(path='foo/bar', md5='b')],
-            '9c34644ba03b7e9f58ebd1caef4215ad',
+            [
+                ZarrChecksum(path="foo/bar", md5="a"),
+                ZarrChecksum(path="foo/baz", md5="b"),
+            ],
+            [],
+            "785295076ae9156b363e442ef6d485e0",
+        ),
+        (
+            [],
+            [
+                ZarrChecksum(path="foo/bar", md5="a"),
+                ZarrChecksum(path="foo/baz", md5="b"),
+            ],
+            "ebca8bb8e716237e0f71657d1045930f",
+        ),
+        (
+            [ZarrChecksum(path="foo/baz", md5="a")],
+            [ZarrChecksum(path="foo/bar", md5="b")],
+            "9c34644ba03b7e9f58ebd1caef4215ad",
         ),
     ],
 )
-def test_zarr_checksum_serializer_aggregate_checksum(file_checksums, directory_checksums, checksum):
+def test_zarr_checksum_serializer_aggregate_checksum(
+    file_checksums, directory_checksums, checksum
+):
     serializer = ZarrJSONChecksumSerializer()
     assert (
         serializer.aggregate_checksum(
@@ -56,11 +72,11 @@ def test_zarr_checksum_serializer_aggregate_checksum(file_checksums, directory_c
 def test_zarr_checksum_serializer_generate_listing():
     serializer = ZarrJSONChecksumSerializer()
     checksums = ZarrChecksums(
-        files=[ZarrChecksum(path='foo/bar', md5='a')],
-        directories=[ZarrChecksum(path='foo/baz', md5='b')],
+        files=[ZarrChecksum(path="foo/bar", md5="a")],
+        directories=[ZarrChecksum(path="foo/baz", md5="b")],
     )
     assert serializer.generate_listing(checksums) == ZarrChecksumListing(
-        checksums=checksums, md5='23076057c0da63f8ab50d0a108db332c'
+        checksums=checksums, md5="23076057c0da63f8ab50d0a108db332c"
     )
 
 
@@ -70,10 +86,10 @@ def test_zarr_serialize():
         serializer.serialize(
             ZarrChecksumListing(
                 checksums=ZarrChecksums(
-                    files=[ZarrChecksum(path='foo/bar', md5='a')],
-                    directories=[ZarrChecksum(path='bar/foo', md5='b')],
+                    files=[ZarrChecksum(path="foo/bar", md5="a")],
+                    directories=[ZarrChecksum(path="bar/foo", md5="b")],
                 ),
-                md5='c',
+                md5="c",
             )
         )
         == '{"checksums":{"directories":[{"md5":"b","path":"bar/foo"}],"files":[{"md5":"a","path":"foo/bar"}]},"md5":"c"}'  # noqa: E501
@@ -86,8 +102,8 @@ def test_zarr_deserialize():
         '{"checksums":{"directories":[{"md5":"b","path":"bar/foo"}],"files":[{"md5":"a","path":"foo/bar"}]},"md5":"c"}'  # noqa: E501
     ) == ZarrChecksumListing(
         checksums=ZarrChecksums(
-            files=[ZarrChecksum(path='foo/bar', md5='a')],
-            directories=[ZarrChecksum(path='bar/foo', md5='b')],
+            files=[ZarrChecksum(path="foo/bar", md5="a")],
+            directories=[ZarrChecksum(path="bar/foo", md5="b")],
         ),
-        md5='c',
+        md5="c",
     )

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import pydantic
 
@@ -119,6 +119,7 @@ class ZarrJSONChecksumSerializer:
 
         This method wraps aggregate_checksum and should not be overridden.
         """
+        print(files)
         if checksums is None:
             checksums = ZarrChecksums(
                 files=files if files is not None else [],
@@ -134,3 +135,14 @@ class ZarrJSONChecksumSerializer:
 # S3. However, an empty zarr file still needs to have a checksum, even if it has no checksum file.
 # For convenience, we define this constant as the "null" checksum.
 EMPTY_CHECKSUM = ZarrJSONChecksumSerializer().generate_listing(ZarrChecksums()).md5
+
+
+def get_checksum(files: Dict[str, str], directories: Dict[str, str]) -> str:
+    """Calculate the checksum of a directory."""
+    checksum_listing = ZarrJSONChecksumSerializer().generate_listing(
+        files=sorted([ZarrChecksum(md5=md5, path=path) for path, md5 in files.items()]),
+        directories=sorted(
+            [ZarrChecksum(md5=md5, path=path) for path, md5 in directories.items()]
+        ),
+    )
+    return checksum_listing.md5

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import total_ordering
 import hashlib
 from typing import Dict, List, Optional
 
@@ -10,6 +11,7 @@ import pydantic
 ENCODING_KWARGS = {"separators": (",", ":")}
 
 
+@total_ordering
 class ZarrChecksum(pydantic.BaseModel):
     """
     A checksum for a single file/directory in a zarr file.

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -42,7 +42,7 @@ class ZarrChecksums(pydantic.BaseModel):
         return self.files == [] and self.directories == []
 
     def _index(self, checksums: List[ZarrChecksum], checksum: ZarrChecksum):
-        # O(n) performance, consider an ordered dict for optimization
+        # O(n) performance, consider using the bisect module or an ordered dict for optimization
         for i in range(0, len(checksums)):
             if checksums[i].path == checksum.path:
                 return i

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -121,11 +121,10 @@ class ZarrJSONChecksumSerializer:
 
         This method wraps aggregate_checksum and should not be overridden.
         """
-        print(files)
         if checksums is None:
             checksums = ZarrChecksums(
-                files=files if files is not None else [],
-                directories=directories if directories is not None else [],
+                files=sorted(files) if files is not None else [],
+                directories=sorted(directories) if directories is not None else [],
             )
         return ZarrChecksumListing(
             checksums=checksums,
@@ -142,9 +141,9 @@ EMPTY_CHECKSUM = ZarrJSONChecksumSerializer().generate_listing(ZarrChecksums()).
 def get_checksum(files: Dict[str, str], directories: Dict[str, str]) -> str:
     """Calculate the checksum of a directory."""
     checksum_listing = ZarrJSONChecksumSerializer().generate_listing(
-        files=sorted([ZarrChecksum(md5=md5, path=path) for path, md5 in files.items()]),
-        directories=sorted(
-            [ZarrChecksum(md5=md5, path=path) for path, md5 in directories.items()]
-        ),
+        files=[ZarrChecksum(md5=md5, path=path) for path, md5 in files.items()],
+        directories=[
+            ZarrChecksum(md5=md5, path=path) for path, md5 in directories.items()
+        ],
     )
     return checksum_listing.md5

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -7,7 +7,7 @@ import pydantic
 
 
 """Passed to the json() method of pydantic models for serialization."""
-ENCODING_KWARGS = {'separators': (',', ':')}
+ENCODING_KWARGS = {"separators": (",", ":")}
 
 
 class ZarrChecksum(pydantic.BaseModel):
@@ -44,7 +44,7 @@ class ZarrChecksums(pydantic.BaseModel):
         for i in range(0, len(checksums)):
             if checksums[i].path == checksum.path:
                 return i
-        raise ValueError('Not found')
+        raise ValueError("Not found")
 
     def add_file_checksums(self, checksums: List[ZarrChecksum]):
         for new_checksum in checksums:
@@ -58,14 +58,18 @@ class ZarrChecksums(pydantic.BaseModel):
         """Add a list of directory checksums to the listing."""
         for new_checksum in checksums:
             try:
-                self.directories[self._index(self.directories, new_checksum)] = new_checksum
+                self.directories[
+                    self._index(self.directories, new_checksum)
+                ] = new_checksum
             except ValueError:
                 self.directories.append(new_checksum)
         self.directories = sorted(self.directories)
 
     def remove_checksums(self, paths: List[str]):
         """Remove a list of paths from the listing."""
-        self.files = sorted(filter(lambda checksum: checksum.path not in paths, self.files))
+        self.files = sorted(
+            filter(lambda checksum: checksum.path not in paths, self.files)
+        )
         self.directories = sorted(
             filter(lambda checksum: checksum.path not in paths, self.directories)
         )
@@ -89,7 +93,7 @@ class ZarrJSONChecksumSerializer:
         # content = json.dumps([asdict(zarr_md5) for zarr_md5 in checksums], separators=(',', ':'))0
         content = checksums.json(**ENCODING_KWARGS)
         h = hashlib.md5()
-        h.update(content.encode('utf-8'))
+        h.update(content.encode("utf-8"))
         return h.hexdigest()
 
     def serialize(self, zarr_checksum_listing: ZarrChecksumListing) -> str:

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+from typing import List, Optional
+
+import pydantic
+
+
+"""Passed to the json() method of pydantic models for serialization."""
+ENCODING_KWARGS = {'separators': (',', ':')}
+
+
+class ZarrChecksum(pydantic.BaseModel):
+    """
+    A checksum for a single file/directory in a zarr file.
+
+    Every file and directory in a zarr archive has a path and a MD5 hash.
+    """
+
+    md5: str
+    path: str
+
+    # To make ZarrChecksums sortable
+    def __lt__(self, other: ZarrChecksum):
+        return self.path < other.path
+
+
+class ZarrChecksums(pydantic.BaseModel):
+    """
+    A set of file and directory checksums.
+
+    This is the data hashed to calculate the checksum of a directory.
+    """
+
+    directories: List[ZarrChecksum] = pydantic.Field(default_factory=list)
+    files: List[ZarrChecksum] = pydantic.Field(default_factory=list)
+
+    @property
+    def is_empty(self):
+        return self.files == [] and self.directories == []
+
+    def _index(self, checksums: List[ZarrChecksum], checksum: ZarrChecksum):
+        # O(n) performance, consider an ordered dict for optimization
+        for i in range(0, len(checksums)):
+            if checksums[i].path == checksum.path:
+                return i
+        raise ValueError('Not found')
+
+    def add_file_checksums(self, checksums: List[ZarrChecksum]):
+        for new_checksum in checksums:
+            try:
+                self.files[self._index(self.files, new_checksum)] = new_checksum
+            except ValueError:
+                self.files.append(new_checksum)
+        self.files = sorted(self.files)
+
+    def add_directory_checksums(self, checksums: List[ZarrChecksum]):
+        """Add a list of directory checksums to the listing."""
+        for new_checksum in checksums:
+            try:
+                self.directories[self._index(self.directories, new_checksum)] = new_checksum
+            except ValueError:
+                self.directories.append(new_checksum)
+        self.directories = sorted(self.directories)
+
+    def remove_checksums(self, paths: List[str]):
+        """Remove a list of paths from the listing."""
+        self.files = sorted(filter(lambda checksum: checksum.path not in paths, self.files))
+        self.directories = sorted(
+            filter(lambda checksum: checksum.path not in paths, self.directories)
+        )
+
+
+class ZarrChecksumListing(pydantic.BaseModel):
+    """
+    A listing of checksums for all sub-files/directories in a zarr directory.
+
+    This is the data serialized in the checksum file.
+    """
+
+    checksums: ZarrChecksums
+    md5: str
+
+
+class ZarrJSONChecksumSerializer:
+    def aggregate_checksum(self, checksums: ZarrChecksums) -> str:
+        """Generate an aggregated checksum for a list of ZarrChecksums."""
+        # Use the most compact separators possible
+        # content = json.dumps([asdict(zarr_md5) for zarr_md5 in checksums], separators=(',', ':'))0
+        content = checksums.json(**ENCODING_KWARGS)
+        h = hashlib.md5()
+        h.update(content.encode('utf-8'))
+        return h.hexdigest()
+
+    def serialize(self, zarr_checksum_listing: ZarrChecksumListing) -> str:
+        """Serialize a ZarrChecksumListing into a string."""
+        # return json.dumps(asdict(zarr_checksum_listing))
+        return zarr_checksum_listing.json(**ENCODING_KWARGS)
+
+    def deserialize(self, json_str: str) -> ZarrChecksumListing:
+        """Deserialize a string into a ZarrChecksumListing."""
+        # listing = ZarrChecksumListing(**json.loads(json_str))
+        # listing.checksums = [ZarrChecksum(**checksum) for checksum in listing.checksums]
+        # return listing
+        return ZarrChecksumListing.parse_raw(json_str)
+
+    def generate_listing(
+        self,
+        checksums: Optional[ZarrChecksums] = None,
+        files: Optional[List[ZarrChecksum]] = None,
+        directories: Optional[List[ZarrChecksum]] = None,
+    ) -> ZarrChecksumListing:
+        """
+        Generate a new ZarrChecksumListing from the given checksums.
+
+        This method wraps aggregate_checksum and should not be overridden.
+        """
+        if checksums is None:
+            checksums = ZarrChecksums(
+                files=files if files is not None else [],
+                directories=directories if directories is not None else [],
+            )
+        return ZarrChecksumListing(
+            checksums=checksums,
+            md5=self.aggregate_checksum(checksums),
+        )
+
+
+# We do not store a checksum file for empty directories since an empty directory doesn't exist in
+# S3. However, an empty zarr file still needs to have a checksum, even if it has no checksum file.
+# For convenience, we define this constant as the "null" checksum.
+EMPTY_CHECKSUM = ZarrJSONChecksumSerializer().generate_listing(ZarrChecksums()).md5


### PR DESCRIPTION
Copy over the non-django-specific code from https://github.com/dandi/dandi-api/blob/master/dandiapi/api/zarr_checksums.py and associated tests.

There is more code in [zarr_checksums.py](https://github.com/dandi/dandi-api/blob/master/dandiapi/api/zarr_checksums.py) that deals with adding/updating/removing batches of checksums to/from the zarr archive, and also with writing the files to S3, but that didn't seem pertinent to the CLI, and it relied heavily on the Django model classes.

The CLI will need to do the legwork of walking the zarr file to feed the checksum algorithm.