### PR TITLE
adding Orcid ID to the contributors

### DIFF
--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -140,6 +140,14 @@ def to_datacite(
                 ]
             else:
                 contr_dict["affiliation"] = []
+            if getattr(contr_el, "orcidID"):
+                orcid_dict = {
+                    "nameIdentifier": contr_el.orcidID,
+                    "nameIdentifierScheme": "ORCID",
+                    "schemeUri": "https://orcid.org/",
+                }
+                contr_dict["nameIdentifiers"] = [orcid_dict]
+
         elif isinstance(contr_el, Organization):
             contr_dict["nameType"] = "Organizational"
 

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -140,9 +140,9 @@ def to_datacite(
                 ]
             else:
                 contr_dict["affiliation"] = []
-            if getattr(contr_el, "orcidID"):
+            if getattr(contr_el, "identifier"):
                 orcid_dict = {
-                    "nameIdentifier": contr_el.orcidID,
+                    "nameIdentifier": contr_el.identifier,
                     "nameIdentifierScheme": "ORCID",
                     "schemeUri": "https://orcid.org/",
                 }

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -423,6 +423,12 @@ class Contributor(DandiBaseModel):
         description="Identifier associated with a sponsored or gift award.",
         nskey="dandi",
     )
+    orcidID: Optional[Identifier] = Field(
+        None,
+        title="Orcid ID",
+        description="Orcid ID....",
+        nskey="dandi",
+    )
 
 
 class Organization(Contributor):

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -423,12 +423,6 @@ class Contributor(DandiBaseModel):
         description="Identifier associated with a sponsored or gift award.",
         nskey="dandi",
     )
-    orcidID: Optional[Identifier] = Field(
-        None,
-        title="Orcid ID",
-        description="Orcid ID....",
-        nskey="dandi",
-    )
 
 
 class Organization(Contributor):

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -222,7 +222,7 @@ def test_datacite(dandi_id, schema):
         ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)
         # the person should be in creators and contributors (with contributorType Other)
-        # Adding Orcid ID to one of the contributors
+        # Adding Orcid ID to the identifier to one of the contributors
         (
             {
                 "contributor": [
@@ -232,7 +232,7 @@ def test_datacite(dandi_id, schema):
                             RoleType("dcite:Author"),
                             RoleType("dcite:Software"),
                         ],
-                        "orcidID": "orcid.org/0000-0001-0000-0000"
+                        "identifier": "0000-0001-0000-0000"
                     },
                     {
                         "name": "B_last, B_first",
@@ -243,7 +243,7 @@ def test_datacite(dandi_id, schema):
             {
                 "creators": (1, {"name": "A_last, A_first",
                                  'nameIdentifiers': [{
-                                     "nameIdentifier": "orcid.org/0000-0001-0000-0000",
+                                     "nameIdentifier": "0000-0001-0000-0000",
                                      "nameIdentifierScheme": "ORCID",
                                      "schemeUri": "https://orcid.org/",
                                  }],
@@ -252,7 +252,7 @@ def test_datacite(dandi_id, schema):
                     2,
                     {"name": "A_last, A_first", "contributorType": "Other",
                      'nameIdentifiers': [{
-                         "nameIdentifier": "orcid.org/0000-0001-0000-0000",
+                         "nameIdentifier": "0000-0001-0000-0000",
                          "nameIdentifierScheme": "ORCID",
                          "schemeUri": "https://orcid.org/",
                      }],

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -222,6 +222,7 @@ def test_datacite(dandi_id, schema):
         ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)
         # the person should be in creators and contributors (with contributorType Other)
+        # Adding Orcid ID to one of the contributors
         (
             {
                 "contributor": [
@@ -231,6 +232,7 @@ def test_datacite(dandi_id, schema):
                             RoleType("dcite:Author"),
                             RoleType("dcite:Software"),
                         ],
+                        "orcidID": "orcid.org/0000-0001-0000-0000"
                     },
                     {
                         "name": "B_last, B_first",
@@ -239,10 +241,22 @@ def test_datacite(dandi_id, schema):
                 ],
             },
             {
-                "creators": (1, {"name": "A_last, A_first"}),
+                "creators": (1, {"name": "A_last, A_first",
+                                 'nameIdentifiers': [{
+                                     "nameIdentifier": "orcid.org/0000-0001-0000-0000",
+                                     "nameIdentifierScheme": "ORCID",
+                                     "schemeUri": "https://orcid.org/",
+                                 }],
+                                 }),
                 "contributors": (
                     2,
-                    {"name": "A_last, A_first", "contributorType": "Other"},
+                    {"name": "A_last, A_first", "contributorType": "Other",
+                     'nameIdentifiers': [{
+                         "nameIdentifier": "orcid.org/0000-0001-0000-0000",
+                         "nameIdentifierScheme": "ORCID",
+                         "schemeUri": "https://orcid.org/",
+                     }],
+                     },
                 ),
             },
         ),


### PR DESCRIPTION
- adding `orcidID` to the contributors fields. It's added to `nameIdentifiers` list in `to_datacite` function. 

fixes #102 