### PR TITLE
get_checksum(): Error on empty input

### DIFF
--- a/dandischema/digests/tests/test_zarr.py
+++ b/dandischema/digests/tests/test_zarr.py
@@ -200,7 +200,6 @@ def test_zarr_deserialize():
 @pytest.mark.parametrize(
     "files,directories,checksum",
     [
-        ({}, {}, "481a2f77ab786a0f45aafd5db0971caa"),
         (
             {"foo/bar": "a"},
             {},
@@ -235,3 +234,8 @@ def test_zarr_deserialize():
 )
 def test_zarr_get_checksum(files, directories, checksum):
     assert get_checksum(files=files, directories=directories) == checksum
+
+
+def test_zarr_get_checksum_empty():
+    with pytest.raises(ValueError):
+        get_checksum(files={}, directories={})

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional
 
 import pydantic
 
-
 """Passed to the json() method of pydantic models for serialization."""
 ENCODING_KWARGS = {"separators": (",", ":")}
 
@@ -140,6 +139,8 @@ EMPTY_CHECKSUM = ZarrJSONChecksumSerializer().generate_listing(ZarrChecksums()).
 
 def get_checksum(files: Dict[str, str], directories: Dict[str, str]) -> str:
     """Calculate the checksum of a directory."""
+    if not files and not directories:
+        raise ValueError("Cannot compute a Zarr checksum for an empty directory")
     checksum_listing = ZarrJSONChecksumSerializer().generate_listing(
         files=[ZarrChecksum(md5=md5, path=path) for path, md5 in files.items()],
         directories=[


### PR DESCRIPTION
As we seem to be developing a consensus that empty directories are not allowed in Zarrs and should be excluded from checksum calculation, this PR makes `get_checksum()` raise a `ValueError` when both `files` and `directories` are empty.  (I was initially going to add the exception to `aggregate_checksum()`, but that messed with `EMPTY_CHECKSUM`, and I'm not sure what should happen to that, so I left it alone for now.)