### PR TITLE
ENH/RF: do not enforce any DANDI instance by default, support DJANGO_DANDI_WEB_APP_URL env var to specify one

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,5 +1,5 @@
-DANDI_SCHEMA_VERSION = "0.6.2"
-ALLOWED_INPUT_SCHEMAS = ["0.4.4", "0.5.1", "0.5.2", "0.6.0", "0.6.1"]
+DANDI_SCHEMA_VERSION = "0.6.3"
+ALLOWED_INPUT_SCHEMAS = ["0.4.4", "0.5.1", "0.5.2", "0.6.0", "0.6.1", "0.6.2"]
 
 # ATM we allow only for a single target version which is current
 # migrate has a guard now for this since it cannot migrate to anything but current

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -40,14 +40,16 @@ if sys.version_info < (3, 8):
 else:
     from typing import Literal
 
+# Use DJANGO_DANDI_WEB_APP_URL to point to a specific deployment.
+DANDI_WEB_APP_URL = os.environ.get("DJANGO_DANDI_WEB_APP_URL", None)
+# Ensure no trailing / for consistency
+DANDI_ARCHIVE_PATTERN = (
+    re.escape(DANDI_WEB_APP_URL.rstrip("/")) if DANDI_WEB_APP_URL else ".*"
+)
+
 # Local or test deployments of dandi-api will insert URLs into the schema that refer to the domain
 # localhost, which is not a valid TLD. To make the metadata valid in those contexts, setting this
 # environment variable will use a less restrictive pydantic field that allows localhost.
-# It is possible also to use DANDI_ALLOWED_LOCALHOST_URLS to point to some other deployment
-# other than dandiarchive.org
-DANDI_ARCHIVE_PATTERN = os.environ.get(
-    "DANDI_ALLOWED_LOCALHOST_URLS", r"https://dandiarchive.org"
-)
 if "DANDI_ALLOW_LOCALHOST_URLS" in os.environ:
     HttpUrl = AnyHttpUrl  # noqa: F811
     DANDI_ARCHIVE_PATTERN = rf"({DANDI_ARCHIVE_PATTERN}|http://localhost(:\d+)?)"
@@ -962,7 +964,7 @@ class CommonModel(DandiBaseModel):
         None, readOnly=True, description="permalink to the item", nskey="schema"
     )
     repository: HttpUrl = Field(
-        "https://dandiarchive.org/",
+        DANDI_WEB_APP_URL,
         readOnly=True,
         description="location of the item",
         nskey="dandi",

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -43,10 +43,14 @@ else:
 # Local or test deployments of dandi-api will insert URLs into the schema that refer to the domain
 # localhost, which is not a valid TLD. To make the metadata valid in those contexts, setting this
 # environment variable will use a less restrictive pydantic field that allows localhost.
-DANDI_ARCHIVE_PATTERN = r"https://dandiarchive.org"
+# It is possible also to use DANDI_ALLOWED_LOCALHOST_URLS to point to some other deployment
+# other than dandiarchive.org
+DANDI_ARCHIVE_PATTERN = os.environ.get(
+    "DANDI_ALLOWED_LOCALHOST_URLS", r"https://dandiarchive.org"
+)
 if "DANDI_ALLOW_LOCALHOST_URLS" in os.environ:
     HttpUrl = AnyHttpUrl  # noqa: F811
-    DANDI_ARCHIVE_PATTERN = r"(https://dandiarchive.org|http://localhost(:\d+)?)"
+    DANDI_ARCHIVE_PATTERN = rf"({DANDI_ARCHIVE_PATTERN}|http://localhost(:\d+)?)"
 
 
 NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -41,10 +41,10 @@ else:
     from typing import Literal
 
 # Use DJANGO_DANDI_WEB_APP_URL to point to a specific deployment.
-DANDI_WEB_APP_URL = os.environ.get("DJANGO_DANDI_WEB_APP_URL", None)
+DANDI_INSTANCE_URL = os.environ.get("DJANGO_DANDI_WEB_APP_URL", None)
 # Ensure no trailing / for consistency
-DANDI_ARCHIVE_PATTERN = (
-    re.escape(DANDI_WEB_APP_URL.rstrip("/")) if DANDI_WEB_APP_URL else ".*"
+DANDI_INSTANCE_URL_PATTERN = (
+    re.escape(DANDI_INSTANCE_URL.rstrip("/")) if DANDI_INSTANCE_URL else ".*"
 )
 
 # Local or test deployments of dandi-api will insert URLs into the schema that refer to the domain
@@ -52,7 +52,9 @@ DANDI_ARCHIVE_PATTERN = (
 # environment variable will use a less restrictive pydantic field that allows localhost.
 if "DANDI_ALLOW_LOCALHOST_URLS" in os.environ:
     HttpUrl = AnyHttpUrl  # noqa: F811
-    DANDI_ARCHIVE_PATTERN = rf"({DANDI_ARCHIVE_PATTERN}|http://localhost(:\d+)?)"
+    DANDI_INSTANCE_URL_PATTERN = (
+        rf"({DANDI_INSTANCE_URL_PATTERN}|http://localhost(:\d+)?)"
+    )
 
 
 NAME_PATTERN = r"^([\w\s\-\.']+),\s+([\w\s\-\.']+)$"
@@ -63,7 +65,9 @@ ASSET_UUID_PATTERN = r"^dandiasset:" + UUID_PATTERN
 VERSION_PATTERN = r"\d{6}/\d+\.\d+\.\d+"
 DANDI_DOI_PATTERN = rf"^10.(48324|80507)/dandi\.{VERSION_PATTERN}"
 DANDI_PUBID_PATTERN = rf"^DANDI:{VERSION_PATTERN}"
-PUBLISHED_VERSION_URL_PATTERN = rf"^{DANDI_ARCHIVE_PATTERN}/dandiset/{VERSION_PATTERN}$"
+PUBLISHED_VERSION_URL_PATTERN = (
+    rf"^{DANDI_INSTANCE_URL_PATTERN}/dandiset/{VERSION_PATTERN}$"
+)
 MD5_PATTERN = r"[0-9a-f]{32}"
 SHA256_PATTERN = r"[0-9a-f]{64}"
 
@@ -964,7 +968,7 @@ class CommonModel(DandiBaseModel):
         None, readOnly=True, description="permalink to the item", nskey="schema"
     )
     repository: HttpUrl = Field(
-        DANDI_WEB_APP_URL,
+        DANDI_INSTANCE_URL,
         readOnly=True,
         description="location of the item",
         nskey="dandi",

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -8,6 +8,7 @@ import pytest
 from .test_datacite import _basic_publishmeta
 from .. import models
 from ..models import (
+    DANDI_ARCHIVE_PATTERN,
     AccessRequirements,
     AccessType,
     Affiliation,
@@ -404,7 +405,7 @@ def test_dantimeta_1():
     error_msgs = [
         "field required",
         "A Dandiset containing no files or zero bytes is not publishable",
-        'string does not match regex "^https://dandiarchive.org/dandiset/'
+        f'string does not match regex "^{DANDI_ARCHIVE_PATTERN}/dandiset/'
         '\\d{6}/\\d+\\.\\d+\\.\\d+$"',
         'string does not match regex "^DANDI:\\d{6}/\\d+\\.\\d+\\.\\d+"',
     ]

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -8,7 +8,7 @@ import pytest
 from .test_datacite import _basic_publishmeta
 from .. import models
 from ..models import (
-    DANDI_ARCHIVE_PATTERN,
+    DANDI_INSTANCE_URL_PATTERN,
     AccessRequirements,
     AccessType,
     Affiliation,
@@ -405,7 +405,7 @@ def test_dantimeta_1():
     error_msgs = [
         "field required",
         "A Dandiset containing no files or zero bytes is not publishable",
-        f'string does not match regex "^{DANDI_ARCHIVE_PATTERN}/dandiset/'
+        f'string does not match regex "^{DANDI_INSTANCE_URL_PATTERN}/dandiset/'
         '\\d{6}/\\d+\\.\\d+\\.\\d+$"',
         'string does not match regex "^DANDI:\\d{6}/\\d+\\.\\d+\\.\\d+"',
     ]


### PR DESCRIPTION
Ref: https://github.com/dandi/dandi-archive/issues/961

I have decided to not hardcode gui-staging. one because the fix is targetting
specifically dandisets testing, and otherwise AFAIK is not needed elsewhere.
If something wants to upload to staging, they can also adjust their CI to point
to whatever instances they upload to

@jwodder -- do you think this would work if we set env var to point to staging in testing of dandisets?