### PR TITLE
Remove JSON customization for `anyOf` elements

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1262,7 +1262,7 @@ class PublishActivity(Activity):
 
 
 class Locus(DandiBaseModel):
-    identifier: Union[Identifier, List[Identifier]] = Field(
+    identifier: Identifier = Field(
         description="Identifier for genotyping locus.",
         json_schema_extra={"nskey": "schema"},
     )
@@ -1274,7 +1274,7 @@ class Locus(DandiBaseModel):
 
 
 class Allele(DandiBaseModel):
-    identifier: Union[Identifier, List[Identifier]] = Field(
+    identifier: Identifier = Field(
         description="Identifier for genotyping allele.",
         json_schema_extra={"nskey": "schema"},
     )

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -563,7 +563,6 @@ class DandiBaseModel(BaseModel):
             if value.get("format", None) == "uri":
                 value["maxLength"] = 1000
             allOf = value.get("allOf")
-            anyOf = value.get("anyOf")
             items = value.get("items")
             if allOf is not None:
                 if len(allOf) == 1 and "$ref" in allOf[0]:
@@ -573,9 +572,6 @@ class DandiBaseModel(BaseModel):
                     value["oneOf"] = value["allOf"]
                     value["type"] = "object"
                     del value["allOf"]
-            if anyOf is not None:
-                if len(anyOf) > 1 and any(["$ref" in val for val in anyOf]):
-                    value["type"] = "object"
             if items is not None:
                 anyOf = items.get("anyOf")
                 if (

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1373,7 +1373,7 @@ class Participant(DandiBaseModel):
         "available. (e.g. from OBI)",
         json_schema_extra={"nskey": "dandi"},
     )
-    genotype: Optional[Union[List[GenotypeInfo], Identifier]] = Field(
+    genotype: Optional[Union[GenotypeInfo, Identifier]] = Field(
         None,
         description="Genotype descriptor of participant or subject if available",
         json_schema_extra={"nskey": "dandi"},

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -604,7 +604,7 @@ class PropertyValue(DandiBaseModel):
     maxValue: Optional[float] = Field(None, json_schema_extra={"nskey": "schema"})
     minValue: Optional[float] = Field(None, json_schema_extra={"nskey": "schema"})
     unitText: Optional[str] = Field(None, json_schema_extra={"nskey": "schema"})
-    value: Union[Any, List[Any]] = Field(
+    value: Any = Field(
         None,
         validate_default=True,
         json_schema_extra={"nskey": "schema"},
@@ -626,7 +626,7 @@ class PropertyValue(DandiBaseModel):
 
     @field_validator("value")
     @classmethod
-    def ensure_value(cls, val: Union[Any, List[Any]]) -> Union[Any, List[Any]]:
+    def ensure_value(cls, val: Any) -> Any:
         if not val:
             raise ValueError(
                 "The value field of a PropertyValue cannot be None or empty."


### PR DESCRIPTION
This PR removes JSON customization for `anyOf` elements. The changes in this PR will allow the tests to pass for #257.

I think the JSON customization for the `anyOf` elements were put in for the specific needs of the web UI. The web UI may no longer need the customization at this point. (@satra Is the customization still needed).

Regardless of the need of the web UI, this customization generates schema element such as:
```json
        "genotype": {
          "anyOf": [
            {
              "$ref": "#/$defs/GenotypeInfo"
            },
            {
              "type": "string"
            }
          ],
          "default": null,
          "description": "Genotype descriptor of participant or subject if available",
          "nskey": "dandi",
          "title": "Genotype",
          "type": "object"
        }
```
which is inconsistent since a `string` is not an `object` in JSON.

If such a customization is still needed, I think we can change the existing customization from
```py
            if anyOf is not None:
                if len(anyOf) > 1 and any(["$ref" in val for val in anyOf]):
                    value["type"] = "object"
```
to
```py
            if anyOf is not None:
                if len(anyOf) > 1 and all(["$ref" in val for val in anyOf]):
                    value["type"] = "object"
```
                    
**Note:**
This PR contains the merge with the `master` branch so that the support of Python 3.8 is dropped.