### PR TITLE
Disallow extra fields other than `"@context"`

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -15,6 +15,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 from warnings import warn
 
@@ -32,7 +33,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from pydantic.json_schema import JsonDict, JsonSchemaValue, JsonValue
+from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
 from zarr_checksum.checksum import InvalidZarrChecksum, ZarrDirectoryDigest
 
@@ -90,19 +91,18 @@ def get_dict_without_context(d: Any) -> Any:
     return d
 
 
-def add_context(json_schema: JsonDict) -> None:
+def add_context(json_schema: dict) -> None:
     """
-    Add the `@context` key to the given JSON schema as a required key represented as a
-    dictionary.
+    Add the `@context` key to the given JSON schema as a required key
 
     :param json_schema: The dictionary representing the JSON schema
 
-    raises: ValueError if the `@context` key is already present in the given dictionary
+    raises: ValueError if the `@context` key is already present in the given schema
     """
     context_key = "@context"
     context_key_title = "@Context"
-    properties: JsonDict = json_schema.get("properties", {})
-    required: list[JsonValue] = json_schema.get("required", [])
+    properties = cast(dict, json_schema.get("properties", {}))
+    required = cast(list, json_schema.get("required", []))
 
     if context_key in properties or context_key in required:
         msg = f"The '{context_key}' key is already present in the given JSON schema."

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -76,6 +76,20 @@ def diff_models(model1: M, model2: M) -> None:
             print(f"{field} is different")
 
 
+def get_dict_without_context(d: Any) -> Any:
+    """
+    If a given object is a dictionary, return a copy of it without the
+    `@context` key. Otherwise, return the input object as is.
+
+    :param d: The given object
+    :return: If the object is a dictionary, a copy of it without the `@context` key;
+             otherwise, the input object as is.
+    """
+    if isinstance(d, dict):
+        return {k: v for k, v in d.items() if k != "@context"}
+    return d
+
+
 class AccessType(Enum):
     """An enumeration of access status options"""
 
@@ -1683,6 +1697,10 @@ class Dandiset(CommonModel):
         "nskey": "dandi",
     }
 
+    # Model validator to remove the `"@context"` key from data instance before
+    # "base" validation is performed.
+    _remove_context_key = model_validator(mode="before")(get_dict_without_context)
+
 
 class BareAsset(CommonModel):
     """Metadata used to describe an asset anywhere (local or server).
@@ -1814,6 +1832,10 @@ class Asset(BareAsset):
     contentUrl: List[AnyHttpUrl] = Field(
         json_schema_extra={"readOnly": True, "nskey": "schema"}
     )
+
+    # Model validator to remove the `"@context"` key from data instance before
+    # "base" validation is performed.
+    _remove_context_key = model_validator(mode="before")(get_dict_without_context)
 
 
 class Publishable(DandiBaseModel):

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -116,6 +116,11 @@ def add_context(json_schema: dict) -> None:
     }
     required.append(context_key)
 
+    # Update the schema
+    # This is needed to handle the case in which the keys are newly created
+    json_schema["properties"] = properties
+    json_schema["required"] = required
+
 
 class AccessType(Enum):
     """An enumeration of access status options"""

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -648,6 +648,8 @@ class DandiBaseModel(BaseModel):
 
         return schema
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class PropertyValue(DandiBaseModel):
     maxValue: Optional[float] = Field(None, json_schema_extra={"nskey": "schema"})
@@ -1726,7 +1728,7 @@ class Dandiset(CommonModel):
     # "base" validation is performed.
     _remove_context_key = model_validator(mode="before")(get_dict_without_context)
 
-    model_config = ConfigDict(extra="allow", json_schema_extra=add_context)
+    model_config = ConfigDict(json_schema_extra=add_context)
 
 
 class BareAsset(CommonModel):

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -114,7 +114,7 @@ def add_context(json_schema: dict) -> None:
         "title": context_key_title,
         "type": "string",
     }
-    required.append(context_key)
+    # required.append(context_key)
 
     # Update the schema
     # This is needed to handle the case in which the keys are newly created

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -93,7 +93,7 @@ def get_dict_without_context(d: Any) -> Any:
 
 def add_context(json_schema: dict) -> None:
     """
-    Add the `@context` key to the given JSON schema as a required key
+    Add the `@context` key to the given JSON schema
 
     :param json_schema: The dictionary representing the JSON schema
 
@@ -114,7 +114,7 @@ def add_context(json_schema: dict) -> None:
         "title": context_key_title,
         "type": "string",
     }
-    # required.append(context_key)
+    # required.append(context_key)  # Uncomment this line to make `@context` required
 
     # Update the schema
     # This is needed to handle the case in which the keys are newly created


### PR DESCRIPTION
This PR closes #75. It addresses #75 in the follow manner.

1. Make the models disallow data instances that have extra fields other than the `"@context"` field in both Pydantic and JSON level.
2. The Pydantic models continue to not have a context field.
3. Data instances with an `"@context"` field can be validated against a Pydantic model but ignored.

<details>
<summary>The solution implemented in this PR is based on the following script.
</summary> 


```py
from typing import Any
import json

from pydantic import BaseModel, ConfigDict, model_validator
from pydantic.json_schema import JsonDict, JsonValue
from jsonschema import validate, Draft202012Validator
import jsonschema


def get_dict_without_context(d: Any) -> Any:
    """
    If a given object is a dictionary, return a copy of it without the
    `@context` key. Otherwise, return the input object as is.

    :param d: The given object
    :return: If the object is a dictionary, a copy of it without the `@context` key;
             otherwise, the input object as is.
    """
    if isinstance(d, dict):
        return {k: v for k, v in d.items() if k != "@context"}
    return d


def add_context(json_schema: JsonDict) -> None:
    """
    Add the `@context` key to the given JSON schema

    :param json_schema: The dictionary representing the JSON schema

    raises: ValueError if the `@context` key is already present in the given dictionary
    """
    context_key = "@context"
    context_key_title = "@Context"
    properties: JsonDict = json_schema.get("properties", {})
    required: list[JsonValue] = json_schema.get("required", [])

    if context_key in properties or context_key in required:
        msg = f"The '{context_key}' key is already present in the given JSON schema."
        raise ValueError(msg)

    properties[context_key] = {
        "format": "uri",
        "minLength": 1,
        "title": context_key_title,
        "type": "string",
    }
    # required.append(context_key)  # Uncomment this line to make `@context` required

    # Update the schema
    # This is needed to handle the case in which the keys are newly created
    json_schema["properties"] = properties
    json_schema["required"] = required


class Foo(BaseModel):
    x: int

    # Model validator to remove the `"@context"` key from data instance before
    # "base" validation is performed.
    _remove_context_key = model_validator(mode="before")(get_dict_without_context)

    model_config = ConfigDict(extra="forbid", json_schema_extra=add_context)


json_schema_ = Foo.model_json_schema()
print(json.dumps(json_schema_, indent=2))
"""
{
  "additionalProperties": false,
  "properties": {
    "x": {
      "title": "X",
      "type": "integer"
    },
    "@context": {
      "format": "uri",
      "minLength": 1,
      "title": "@Context",
      "type": "string"
    }
  },
  "required": [
    "x",
    "@context"
  ],
  "title": "Foo",
  "type": "object"
}
"""

instance_json_str = '{"x": 1}'
instance_json_str_with_context = '{"@context": "not a valid URI", "x": 1}'
instance_json_str_with_extra = '{"x": 1, "e": 42}'

vv = Foo.model_validate_json(instance_json_str)
print("\n====================================")
print(f"vv: {vv!r}")
"vv: Foo(x=1)"

# Ignore the context field in Pydantic level
vv_with_context = Foo.model_validate_json(instance_json_str_with_context)
print("\n====================================")
print(f"vv_with_context: {vv_with_context!r}")
"vv_with_context: Foo(x=1)"

# Disallow other extra fields in Pydantic level
try:
    Foo.model_validate_json(instance_json_str_with_extra)
except ValueError as e:
    print("\n====================================")
    print(e)
    """
    1 validation error for Foo
    e
      Extra inputs are not permitted [type=extra_forbidden, input_value=42, input_type=int]
        For further information visit https://errors.pydantic.dev/2.9/v/extra_forbidden
    """

instance = {"@context": "https://schema.org", "x": 1}
instance_with_invalid_context = {"@context": "invalid context", "x": 1}
instance_missing_context = {"x": 1}
instance_with_extra = {"@context": "https://schema.org", "x": 1, "e": 42}

# Validate an instance with valid context and x field
validate(instance, json_schema_, format_checker=Draft202012Validator.FORMAT_CHECKER)

# Instance with invalid context fails validation
try:
    validate(
        instance_with_invalid_context,
        json_schema_,
        format_checker=Draft202012Validator.FORMAT_CHECKER,
    )
except jsonschema.exceptions.ValidationError as e:
    print("\n====================================")
    print(e)
    """
    'invalid context' is not a 'uri'
    Failed validating 'format' in schema['properties']['@context']:
        {'format': 'uri', 'minLength': 1, 'title': '@Context', 'type': 'string'}
    On instance['@context']:
        'invalid context'
    """

# The context field is optional
validate(
    instance_missing_context,
    json_schema_,
    format_checker=Draft202012Validator.FORMAT_CHECKER,
)
print("\n====================================")
print("Instance without the `@context` key is valid")
"Instance without the `@context` key is valid"


# Instance with extra field fails validation
try:
    validate(
        instance_with_extra,
        json_schema_,
        format_checker=Draft202012Validator.FORMAT_CHECKER,
    )
except jsonschema.exceptions.ValidationError as e:
    print("\n====================================")
    print(e)
    """
    Additional properties are not allowed ('e' was unexpected)
    Failed validating 'additionalProperties' in schema:
        {'additionalProperties': False,
         'properties': {'x': {'title': 'X', 'type': 'integer'},
                        '@context': {'format': 'uri',
                                     'minLength': 1,
                                     'title': '@Context',
                                     'type': 'string'}},
         'required': ['x', '@context'],
         'title': 'Foo',
         'type': 'object'}
    On instance:
        {'@context': 'https://schema.org', 'x': 1, 'e': 42}
    """
```
</details>


TODOs
- [x] ensure that tests pass
  - [x] @yarikoptic: let's for now make `@context` optional and then discuss
- [ ] run against all dandisets metadata  (manifests) and see if any gets (more) broken.
  - [ ] we have them already fetched to drogon -- just run there.  `*/*/dandiset.jsonld` files under `/mnt/backup/dandi/dandiset-manifests-s3cmd` .
    - [X] check at Pydantic level (analysis available at https://github.com/dandi/dandi-schema/pull/266#issuecomment-2603164223)
    - [x] check at JSONSchema level
  - The `diff-manifests-reports` subcommand of https://github.com/dandi/dandisets-linkml-status-tools is the tool for the checking
  - Reports of the checking is at https://github.com/dandi/dandi-schema-status
- [ ] check meditor
- [ ] provide tests for introduced changes