### PR TITLE
Improve `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Every [Dandiset](https://docs.dandiarchive.org/user-guide-sharing/creating-dandi
 or associated asset is described by a structured metadata object that can be
 retrieved through the DANDI API. The `dandi-schema` library provides Python data models
 and helper utilities to create, validate, migrate, and manage these metadata objects.
-It uses [Pydantic](https://github.com/samuelcolvin/pydantic) models to define metadata
+It uses [Pydantic](https://github.com/pydantic/pydantic) models to define metadata
 models, and the JSON Schema schemas corresponding to the Pydantic models are generated,
 versioned, and stored in the [dandi/schema](https://github.com/dandi/schema) repository
 with an associated `context.json` file for JSON-LD compliance. **Both** representations


### PR DESCRIPTION
This PR improves `README.md`. Particularly,


1. Give definition of what DANDI is
2. Remove the markings that mark Dandiset as code since Dandiset is really used as a noun in the document as in https://docs.dandiarchive.org/user-guide-sharing/creating-dandiset/
3. Remove some redundancies
4. Add reference link to the metadata integration diagram in DANDI Docs

**Note**

Information regarding vendorization of the schema will be added at part of #294 