### PR TITLE
Release new schema 0.7.0 for addition of the releaseNotes

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,6 +1,6 @@
 from packaging.version import Version as _Version
 
-DANDI_SCHEMA_VERSION = "0.6.10"
+DANDI_SCHEMA_VERSION = "0.7.0"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -15,6 +15,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.7",
     "0.6.8",
     "0.6.9",
+    "0.6.10",
     DANDI_SCHEMA_VERSION,
 ]
 


### PR DESCRIPTION
This is a cut version of

- #342

which added a wishful component for allowing downgrading model versions.  That would take more work, so will just progress now with releasing both new added releaseNotes and devendorization (https://github.com/dandi/dandi-schema/pull/294), hence "minor" component boost for both schema and library

note: `dandi-cli` tests would fail since dandi-archive component would not be ready to publish with a new version of the schema ATM.