### PR TITLE
Upgrade version of intuit/auto to use for releases to current 11.3.6, add use of "released" plugin, configure release action to act on dispatch event

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,7 +1,15 @@
 {
-    "onlyPublishWithReleaseLabel": true,
     "baseBranch": "master",
     "author": "DANDI Bot <team@dandiarchive.org>",
     "noVersionPrefix": true,
-    "plugins": ["git-tag"]
+    "plugins": [
+        "git-tag",
+        [
+            "exec",
+            {
+                  "afterRelease": "python -m build && twine upload dist/*"
+            }
+        ],
+        "released"
+    ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   AUTO_VERSION: v11.3.6
@@ -103,9 +104,12 @@ jobs:
 
       - name: Create release
         run: |
-          ~/auto shipit -vv
-          python -m build
-          twine upload dist/*
+          echo "@${{ github.actor }} is creating a release triggered by ${{ github.event_name }}"
+          if [ "${{ github.event_name }}" = workflow_dispatch ]
+          then opts=
+          else opts=--only-publish-with-release-label
+          fi
+          ~/auto shipit -vv $opts
         env:
           GH_TOKEN: ${{ secrets.DANDI_GITHUB_TOKEN }}
           TWINE_USERNAME: __token__


### PR DESCRIPTION
Also I removed the comment which is no longer applicable since described reasoning for some older version but did not state that we had to stick to that one

The hope is that it would help addressing some aspects (outdated pypi api usage etc) of 
- #345 