### PR TITLE
Remove use of Python 3.9 in tests against dandi-cli

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -24,7 +24,6 @@ jobs:
           - macos-latest
         python:
           # Use the only Python which is ATM also used by dandi-api
-          # - 3.9
           # - '3.10'
           - '3.11'
           # - '3.12'
@@ -35,18 +34,13 @@ jobs:
           - normal
         include:
           - os: ubuntu-latest
-            python: 3.9
+            python: "3.10"
             mode: dandi-devel
             version: master
           - os: ubuntu-latest
-            python: 3.9
+            python: "3.10"
             mode: dandi-devel
             version: release
-        exclude:
-          # Temporarily disabled due to h5py/hdf5 dependency issue
-          # See <https://github.com/dandi/dandi-cli/pull/315>
-          - os: windows-latest
-            python: 3.9
     steps:
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
As of https://github.com/dandi/dandi-cli/pull/1759, dandi-cli has drop support of Python 3.9, so testing against dandi-cli in a Python 3.9 environment is no longer relevant and causes the following error.

<img width="1606" height="699" alt="Screenshot 2025-12-08 at 5 23 22 PM" src="https://github.com/user-attachments/assets/a0b6ceb6-4558-4c52-919d-0bf01e5a580b" />


This PR removes the use of Python 3.9 in integration tests against dandi-cli.