### PR TITLE
ci: update test configuration to vendorize dandiapi instance in tests

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -32,6 +32,12 @@ jobs:
           - release
         mode:
           - normal
+        vendored_dandiapi:
+          # Allow vendor information for the dandi-api instance to default to
+          #   the default values specified in
+          #   dandi/tests/data/dandiarchive-docker/docker-compose.yml of the dandi-cli
+          #   repo.
+          - default
         include:
           - os: ubuntu-latest
             python: "3.10"
@@ -41,6 +47,22 @@ jobs:
             python: "3.10"
             mode: dandi-devel
             version: release
+          - os: ubuntu-latest
+            python: "3.11"
+            mode: normal
+            version: master
+            vendored_dandiapi: ember-dandi
+            instance_name: EMBER-DANDI
+            instance_identifier: 'RRID:SCR_026700'
+            doi_prefix: '10.82754'
+          - os: ubuntu-latest
+            python: "3.11"
+            mode: normal
+            version: release
+            vendored_dandiapi: ember-dandi
+            instance_name: EMBER-DANDI
+            instance_identifier: 'RRID:SCR_026700'
+            doi_prefix: '10.82754'
     steps:
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v6
@@ -92,6 +114,21 @@ jobs:
             -f tools/api-with-schema.Dockerfile \
             .
         working-directory: dandischema
+
+      # Set only if matrix.instance_name is defined
+      - name: Set DANDI_TESTS_INSTANCE_NAME
+        if: ${{ matrix.instance_name }}
+        run: echo "DANDI_TESTS_INSTANCE_NAME=${{ matrix.instance_name }}" >> "$GITHUB_ENV"
+
+      # Set only if matrix.instance_identifier is defined
+      - name: Set DANDI_TESTS_INSTANCE_IDENTIFIER
+        if: ${{ matrix.instance_identifier }}
+        run: echo "DANDI_TESTS_INSTANCE_IDENTIFIER=${{ matrix.instance_identifier }}" >> "$GITHUB_ENV"
+
+      # Set only if matrix.doi_prefix is defined
+      - name: Set DANDI_TESTS_DOI_PREFIX
+        if: ${{ matrix.doi_prefix }}
+        run: echo "DANDI_TESTS_DOI_PREFIX=${{ matrix.doi_prefix }}" >> "$GITHUB_ENV"
 
       - name: Run dandi-cli tests
         run: python -m pytest -s -v --pyargs dandi


### PR DESCRIPTION
This PR is a duplicate of https://github.com/dandi/dandi-schema/pull/355 since https://github.com/dandi/dandi-schema/pull/355 was accidentally closed by mistake.


This PR updates test configuration in a GH workflow to vendorize the dandiapi instance used in tests. It builds on https://github.com/dandi/dandi-cli/pull/1756, so it only works property after https://github.com/dandi/dandi-cli/pull/1756 is merged.

This PR closes #350.

**Notes**: 

- [x] 1. For this PR to have any effect, https://github.com/dandi/dandi-cli/pull/1756 must be merged.
- [x] 2. After https://github.com/dandi/dandi-cli/pull/1756 is merged, this PR is expected to fail until all more vendorization efforts for dandi-cli, , such as https://github.com/dandi/dandi-cli/issues/1752, are complete, and related changes are released.