### PR TITLE
test: add wait time after DOI creation

### DIFF
--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -2,6 +2,7 @@ from enum import Enum
 import json
 import os
 import random
+from time import sleep
 from typing import TYPE_CHECKING, Any, Dict, Tuple, cast
 
 from jsonschema import Draft7Validator
@@ -157,6 +158,10 @@ def datacite_post(datacite: dict, doi: str) -> None:
         auth=(os.environ["DATACITE_DEV_LOGIN"], os.environ["DATACITE_DEV_PASSWORD"]),
     )
     rp.raise_for_status()
+
+    # Wait for DataCite to correctly process the DOI creation
+    #   to avoid the bug documented in https://github.com/datacite/datacite/issues/2307
+    sleep(3)
 
     # checking if i'm able to get the url
     rg = requests.get(url=f"https://api.test.datacite.org/dois/{doi}/activities")


### PR DESCRIPTION
To avoid the behavior of the bug documented at https://github.com/datacite/datacite/issues/2307 so that our test servers are not populated with undeletable DOIs.

This PR implements the first option of the three listed below to address the the behavior of the bug documented at https://github.com/datacite/datacite/issues/2307. If undeletable DOIs continue to occur after this PR is applied. We should consider implementing another option instead.

1. Insert a waiting period of about 1-2 seconds between the creation and deletion of the same DOI. (This solution is not perfect since a GH Action job that is running such a test can get cancelled just after the creation of a DOI, and a created DOI may not be deleted. However, the situation of a created DOI that is not eventually deleted is unlikely, and this solution ensures that a created DOI can always be deleted. You may just need to delete some of them manually).
2. Have the tests only create DOIs but not delete them, and run another CI job to delete the DOIs created by the tests periodically. This approach also ensure the created DOIs are deletable. However, those DOIs will remain in the server for a period of time.
3. Implement option 1 but also a CI job to periodically remove any created DOIs that have not been deleted.


