### PR TITLE
maint: drop Python 3.9 support, require Python >=3.10

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install dandischema
         run: python -m pip install .

--- a/.github/workflows/test-nonetwork.yml
+++ b/.github/workflows/test-nonetwork.yml
@@ -19,7 +19,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python:
-          - 3.9
           - '3.10'
           - '3.11'
           - '3.12'

--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dandischema
         run: python -m pip install .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,23 +16,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python: ['3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12']
         vendored_env: [unvendored]
         include:
           - os: ubuntu-latest
-            python: '3.9'
+            python: '3.10'
             vendored_env: dandi
             instance_name: DANDI
             instance_identifier: 'RRID:SCR_017571'
             doi_prefix: '10.80507'
           - os: ubuntu-latest
-            python: '3.9'
+            python: '3.10'
             vendored_env: ember-dandi
             instance_name: EMBER-DANDI
             instance_identifier: 'RRID:SCR_026700'
             doi_prefix: '10.82754'
           - os: ubuntu-latest
-            python: '3.9'
+            python: '3.10'
             vendored_env: ember-dandi-no-doi
             instance_name: EMBER-DANDI
     steps:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -26,7 +25,7 @@ project_urls =
     Source Code = https://github.com/dandi/dandischema
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     jsonschema[format]
     packaging>=14.0


### PR DESCRIPTION
## Summary

- Remove Python 3.9 from the test matrix in all CI workflows
- Update `python_requires = >=3.10` in `setup.cfg`
- Drop the `Programming Language :: Python :: 3.9` classifier

Python 3.9 reached end-of-life in October 2024. Additionally,
`black>=26.x` (pinned in `.pre-commit-config.yaml`) requires Python>=3.10, making 3.9 incompatible with the current pre-commit setup.

## Test plan

- [x] All CI jobs pass with Python 3.10 as the new minimum
- [x] Confirm `black` pre-commit hook installs and runs correctly in the updated environment

🤖 Generated with [Claude Code](https://claude.ai/claude-code)