### PR TITLE
ci: remove last use of DANDI_ALLOW_LOCALHOST_URLS env var

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       NO_ET: 1
-      DANDI_ALLOW_LOCALHOST_URLS: 1
       DANDI_TESTS_PULL_DOCKER_COMPOSE: 0
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Removes the last remaining reference to `DANDI_ALLOW_LOCALHOST_URLS`
from `.github/workflows/test-dandi-cli.yml`.

## Why this closes #67

Issue #67 was filed because the codebase required `DANDI_ALLOW_LOCALHOST_URLS`
to be set in test environments to permit localhost URLs, which were
otherwise rejected by strict URL validation in the Pydantic models.

The root cause was addressed in commit a12f2e4 (2023): `DANDI_INSTANCE_URL`
was defaulted to `localhost` and `AnyHttpUrl` was adopted
unconditionally, eliminating the need for the env var workaround
entirely. Since then, `DANDI_ALLOW_LOCALHOST_URLS` has been a no-op —
no code in the repository reads it.

This PR removes its last mention in the dandi-cli test workflow,
completing the cleanup originally requested in #67.

This cleanup was identified while running the
[`/issue-triage`](https://github.com/con/skills/tree/master/issue-triage)
skill against the open issues of this repository, which flagged #67 as
likely resolved with HIGH confidence.

Closes #67.

## Test plan

- [x] dandi-cli CI passes without `DANDI_ALLOW_LOCALHOST_URLS` set
      (no behavioral change expected — the env var has been unread since 2023).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)