### PR TITLE
Introduce Hatch-managed environments to the project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ all = [
     "dandischema[test]",
 ]
 
+[tool.hatch.envs.default]
+installer = "uv"
+python = "3.10"
+
 [tool.setuptools.packages.find]
 namespaces = true
 include = ["dandischema*"]


### PR DESCRIPTION
## Summary
Introduce Hatch-managed environments to the project.

- Adds `[tool.hatch.envs.default]` section to `pyproject.toml`
- Sets `uv` as the installer for the default Hatch environment
- Pins the default Python version to 3.10

## Test plan
- [x] Verify `hatch env create` uses uv as the installer

## TODOs 
- [x] This PR is based on https://github.com/dandi/dandi-schema/pull/379. To get the relevant commits in this PR rebase on `master` after https://github.com/dandi/dandi-schema/pull/379 is merged to `master`. 
- [x] This PR should be merged after https://github.com/dandi/dandi-schema/pull/379 is merged to `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)