### PR TITLE
feat: provide `prefixes` definition in the overlay file

### DIFF
--- a/dandischema/models_overlay.yaml
+++ b/dandischema/models_overlay.yaml
@@ -2,3 +2,27 @@ name: dandi-schema
 id: https://schema.dandiarchive.org/s/dandi/v0.7
 version: 0.7.0
 status: eunal:concept-status/DRAFT
+
+prefixes:
+  dandi: http://schema.dandiarchive.org/
+  dcite: http://schema.dandiarchive.org/datacite/
+  dandiasset: http://dandiarchive.org/asset/
+  DANDI: http://dandiarchive.org/dandiset/
+  dct: http://purl.org/dc/terms/
+  owl: http://www.w3.org/2002/07/owl#
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfa: http://www.w3.org/ns/rdfa#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  schema: http://schema.org/
+  xsd: http://www.w3.org/2001/XMLSchema#
+  skos: http://www.w3.org/2004/02/skos/core#
+  prov: http://www.w3.org/ns/prov#
+  pav: http://purl.org/pav/
+  nidm: http://purl.org/nidash/nidm#
+  uuid: http://uuid.repronim.org/
+  rs: http://schema.repronim.org/
+  RRID: "https://scicrunch.org/resolver/RRID:"
+  ORCID: https://orcid.org/
+  ROR: https://ror.org/
+  PATO: http://purl.obolibrary.org/obo/PATO_
+  spdx: http://spdx.org/licenses/


### PR DESCRIPTION
These prefixes are copied from
https://github.com/dandi/schema/blob/master/releases/0.7.0/context.json