### PR TITLE
Replace discriminated unions with simple unions in models

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1277,14 +1277,9 @@ class Activity(DandiBaseModel):
 
     # isPartOf: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
     # hasPart: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
-    wasAssociatedWith: Optional[
-        List[
-            Annotated[
-                Union[Person, Organization, Software, Agent],
-                Field(discriminator="schemaKey"),
-            ]
-        ]
-    ] = Field(None, json_schema_extra={"nskey": "prov"})
+    wasAssociatedWith: Optional[List[Union[Person, Organization, Software, Agent],]] = (
+        Field(None, json_schema_extra={"nskey": "prov"})
+    )
     used: Optional[List[Equipment]] = Field(
         None,
         description="A listing of equipment used for the activity.",
@@ -1566,21 +1561,13 @@ class CommonModel(DandiBaseModel):
         description="A description of the item.",
         json_schema_extra={"nskey": "schema"},
     )
-    contributor: Optional[
-        List[Annotated[Union[Person, Organization], Field(discriminator="schemaKey")]]
-    ] = Field(
+    contributor: Optional[List[Union[Person, Organization]]] = Field(
         None,
         title="Contributors",
         description="Contributors to this item: persons or organizations.",
         json_schema_extra={"nskey": "schema"},
     )
-    about: Optional[
-        List[
-            Annotated[
-                Union[Disorder, Anatomy, GenericType], Field(discriminator="schemaKey")
-            ]
-        ]
-    ] = Field(
+    about: Optional[List[Union[Disorder, Anatomy, GenericType]]] = Field(
         None,
         title="Subject matter of the dataset",
         description="The subject matter of the content, such as disorders, brain anatomy.",
@@ -1711,9 +1698,7 @@ class Dandiset(CommonModel):
         max_length=10000,
         json_schema_extra={"nskey": "schema"},
     )
-    contributor: List[
-        Annotated[Union[Person, Organization], Field(discriminator="schemaKey")]
-    ] = Field(
+    contributor: List[Union[Person, Organization]] = Field(
         title="Dandiset contributors",
         description="People or Organizations that have contributed to this Dandiset.",
         json_schema_extra={"nskey": "schema"},

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1276,14 +1276,9 @@ class Activity(DandiBaseModel):
 
     # isPartOf: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
     # hasPart: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
-    wasAssociatedWith: Optional[
-        List[
-            Annotated[
-                Union[Person, Organization, Software, Agent],
-                Field(discriminator="schemaKey"),
-            ]
-        ]
-    ] = Field(None, json_schema_extra={"nskey": "prov"})
+    wasAssociatedWith: Optional[List[Union[Person, Organization, Software, Agent],]] = (
+        Field(None, json_schema_extra={"nskey": "prov"})
+    )
     used: Optional[List[Equipment]] = Field(
         None,
         description="A listing of equipment used for the activity.",
@@ -1565,21 +1560,13 @@ class CommonModel(DandiBaseModel):
         description="A description of the item.",
         json_schema_extra={"nskey": "schema"},
     )
-    contributor: Optional[
-        List[Annotated[Union[Person, Organization], Field(discriminator="schemaKey")]]
-    ] = Field(
+    contributor: Optional[List[Union[Person, Organization]]] = Field(
         None,
         title="Contributors",
         description="Contributors to this item: persons or organizations.",
         json_schema_extra={"nskey": "schema"},
     )
-    about: Optional[
-        List[
-            Annotated[
-                Union[Disorder, Anatomy, GenericType], Field(discriminator="schemaKey")
-            ]
-        ]
-    ] = Field(
+    about: Optional[List[Union[Disorder, Anatomy, GenericType]]] = Field(
         None,
         title="Subject matter of the dataset",
         description="The subject matter of the content, such as disorders, brain anatomy.",
@@ -1710,9 +1697,7 @@ class Dandiset(CommonModel):
         max_length=10000,
         json_schema_extra={"nskey": "schema"},
     )
-    contributor: List[
-        Annotated[Union[Person, Organization], Field(discriminator="schemaKey")]
-    ] = Field(
+    contributor: List[Union[Person, Organization]] = Field(
         title="Dandiset contributors",
         description="People or Organizations that have contributed to this Dandiset.",
         json_schema_extra={"nskey": "schema"},


### PR DESCRIPTION
## Summary

Removes the use of discriminated unions in favor of plain `Union[...]` for the `wasAssociatedWith`, `contributor`, and `about` fields.

This has no effect on validation correctness: each union member has a distinct `schemaKey: Literal[...]` value, so Pydantic's smart union mode resolves the correct type without a discriminator.

The primary motivation is to enable translation to LinkML via pydantic2linkml, since LinkML has no comparable feature to discriminated unions (see dandi/pydantic2linkml#39).

Notes:
Use of discriminated unions was introduced to improve validation error messages per https://github.com/dandi/dandi-schema/issues/244.

## Test plan

- [x] All existing tests pass (`240 passed, 3 skipped`)
- [ ] Analyze the effect of this change on meditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)