### PR TITLE
Replace sed post-processing in `2pydantic` with gen-pydantic template override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
 ]
 [tool.hatch.envs.linkml-auto-converted.scripts]
 2linkml = "pydantic2linkml -l INFO -M dandischema/models_merge.yaml -O dandischema/models_overlay.yaml dandischema.models | sed -e 's,0x[0-9a-ef]*,0xADDRESS,g' -E -e 's,([^[:space:]]+):[0-9]+,\\1:NUMBER,g' | tools/linkml_conversion_tools/sanitize-yaml > dandischema/models.yaml"
-2pydantic = "gen-pydantic --black dandischema/models.yaml | sed -E -e 's,[a-z]+COLON,,g' > dandischema/models_linkml.py"
+2pydantic = "gen-pydantic --black --template-dir tools/linkml_conversion_tools/pydantic_templates dandischema/models.yaml > dandischema/models_linkml.py"
 2json = "d=dandischema/models_linkml; rm -rf $d && mkdir -p $d && for t in Dandiset Asset PublishedDandiset PublishedAsset; do gen-json-schema --title-from title -t $t dandischema/models.yaml >| $d/$t.json; done"
 pydantic2json = "d=dandischema/models_pydantic; rm -rf $d && mkdir -p $d && python tools/pubschemata.py $d && mv $d/*/*json $d/"
 

--- a/tools/linkml_conversion_tools/pydantic_templates/enum.py.jinja
+++ b/tools/linkml_conversion_tools/pydantic_templates/enum.py.jinja
@@ -1,0 +1,18 @@
+class {{ name }}(str{% if values %}, Enum{% endif %}):
+{% if description %}
+    """
+    {{ description }}
+    """
+{% endif %}
+{% if values %}
+    {% for pv in values.values() %}
+    {{ pv.label.split("COLON") | last }} = "{{pv.value}}"
+        {% if pv.description %}
+    """
+    {{ pv.description | indent(width=4) }}
+    """
+        {% endif %}
+    {% endfor %}
+{% else %}
+    pass
+{% endif %}


### PR DESCRIPTION
## Summary
- Replace the `sed -E 's,[a-z]+COLON,,g'` post-processing in the `2pydantic` hatch script with an `enum.py.jinja` override passed to `gen-pydantic` via `--template-dir`.
- The substitution now happens at the point where enum labels are emitted (via `pv.label.split("COLON") | last`), rather than as blind text replacement over the whole generated file.
- This removes the dependency on a system `sed` from the Pydantic generation pipeline, which makes the "Validate the data instances against the Pydantic models generated from the LinkML schema" task in #408 easier to implement (e.g. generating the Pydantic models in-process or in environments where shelling out to `sed` is awkward).

## Why
The old pipeline was:

```
gen-pydantic --black dandischema/models.yaml | sed -E -e 's,[a-z]+COLON,,g' > dandischema/models_linkml.py
```

`gen-pydantic` emits enum members whose Python identifiers carry LinkML's namespace-prefix munging — e.g. `dandiCOLONOpenAccess = "dandi:OpenAccess"`. The `sed` stripped the `<prefix>COLON` portion file-wide.

Doing this at the template level is more precise:
- it only touches the place where the prefix is known to be a munging artifact (the enum member label), not arbitrary file text;
- the intent is explicit in the template rather than hidden in a regex pipeline;
- it drops the runtime dependency on a system `sed`, which is useful for #408 (validating data instances against the generated Pydantic models) where we'd rather not have the generation step shell out.

## Verification
Generated `models_linkml.py` two ways from `dandischema/models.yaml` (restored from the `linkml-auto-converted` branch):

1. old: `gen-pydantic --black … | sed -E 's,[a-z]+COLON,,g'`
2. new: `gen-pydantic --black --template-dir tools/linkml_conversion_tools/pydantic_templates …`

`diff` of the two outputs is empty — byte-identical. All 116 `COLON` occurrences in the raw `gen-pydantic` output are preceded by a lowercase prefix, so `split("COLON") | last` is equivalent to the `sed` on this schema.

## Test plan
- [x] Compared old vs new output on `dandischema/models.yaml` from `linkml-auto-converted` — byte-identical.
- [ ] On the `linkml-auto-converted` branch (or one stacked on top), run `hatch run linkml-auto-converted:2pydantic` and confirm `dandischema/models_linkml.py` is unchanged from before this PR.
