### PR TITLE
Inherit readOnly from CommonModel for access of BareAsset

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1800,7 +1800,7 @@ class BareAsset(CommonModel):
     access: List[AccessRequirements] = Field(
         title="Access information",
         default_factory=lambda: [AccessRequirements(status=AccessType.OpenAccess)],
-        json_schema_extra={"nskey": DANDI_NSKEY},
+        json_schema_extra={"nskey": DANDI_NSKEY, "readOnly": True},
         max_length=1,
     )
 


### PR DESCRIPTION
This PR also resolves #413.

## Finding

The `access` field is defined in two places in `dandischema/models.py`:

- `CommonModel.access` carries `"readOnly": True` in its `json_schema_extra`.
- `BareAsset.access` overrides it (per the comment `# overload to restrict with max_items=1`) but omits `"readOnly": True`.

Git history confirms that omitting `"readOnly": True` from `BareAsset.access` is an oversight, not an intentional difference:

- `BareAsset.access` was introduced in commit 78dd70c ("fix: restrict access metadata for asset to one item", 2021-07-27) without `readOnly`. It has never carried `readOnly` since.
- `CommonModel.access` gained `readOnly=True` later, in commit c01ab9c ("enable embargoed access fields", 2022-01-13). That commit modified only `CommonModel.access` and did not update the `BareAsset.access` override sitting ~100 lines below.

Given that the override's stated purpose is solely tightening `max_items` (now `max_length`) to 1, the rest of the field's metadata — including `readOnly` — should track the base class.
