### PR TITLE
feat: let `wasGeneratedBy` in `BareAsset` and `Dandiset` to have range of `Activity`

### DIFF
--- a/dandischema/models_merge.yaml
+++ b/dandischema/models_merge.yaml
@@ -14,6 +14,14 @@ classes:
       - "MANUAL_NOTE: The default of the `schemaKey` field in the corresponding Pydantic
       model in `dandischema.models` is not the model's name. Adjustment to the inherited
       `schemaKey` slot may be needed."
+    slot_usage:
+      wasGeneratedBy:
+        notes: null
+        any_of: null
+  Dandiset:
+    slot_usage:
+      wasGeneratedBy:
+        notes: null
   PublishedAsset:
     notes:
       - "MANUAL_NOTE: The default of the `schemaKey` field in the corresponding Pydantic


### PR DESCRIPTION
This PR is a possible solution to https://github.com/dandi/dandi-schema/issues/406

With `schemaKey` being the designator
type, instances of subclasses of
`Activity` should be able to validate
into the corresponding subclasses. Though
this solution would relex the schema a bit
for `BareAsset` and `Dandiset`

