### PR TITLE
Consolidate Asset/Dandiset models; gate publish validation on datePublished

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,6 +1,6 @@
 from packaging.version import Version as _Version
 
-DANDI_SCHEMA_VERSION = "0.7.0"
+DANDI_SCHEMA_VERSION = "0.8.0"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -16,6 +16,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.8",
     "0.6.9",
     "0.6.10",
+    "0.7.0",
     DANDI_SCHEMA_VERSION,
 ]
 

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -118,17 +118,23 @@ def to_datacite(
     validate: bool = False,
     publish: bool = False,
 ) -> dict:
-    """Convert published Dandiset metadata to Datacite"""
+    """Convert published Dandiset metadata to Datacite
+
+    Raises
+    ------
+    ValueError
+        If ``meta`` does not represent published Dandiset metadata, i.e. its
+        ``datePublished`` is not set.
+    """
 
     instance_config = get_instance_config()
 
     if not isinstance(meta, PublishedDandiset):
         meta = PublishedDandiset(**meta)
 
-    # ``to_datacite`` operates on *published* Dandiset metadata. Since the
-    # publication-only fields are now optional on ``Dandiset`` (gated on
-    # ``datePublished``), enforce the precondition the ``PublishedDandiset`` type
-    # used to guarantee.
+    # ``to_datacite`` operates on *published* Dandiset metadata, but the
+    # publication-only fields are optional on ``Dandiset`` (gated on
+    # ``datePublished``), so enforce that precondition explicitly here.
     if meta.datePublished is None:
         raise ValueError(
             "to_datacite requires published Dandiset metadata, but datePublished "

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -125,6 +125,16 @@ def to_datacite(
     if not isinstance(meta, PublishedDandiset):
         meta = PublishedDandiset(**meta)
 
+    # ``to_datacite`` operates on *published* Dandiset metadata. Since the
+    # publication-only fields are now optional on ``Dandiset`` (gated on
+    # ``datePublished``), enforce the precondition the ``PublishedDandiset`` type
+    # used to guarantee.
+    if meta.datePublished is None:
+        raise ValueError(
+            "to_datacite requires published Dandiset metadata, but datePublished "
+            "is not set"
+        )
+
     attributes: Dict[str, Any] = {}
     if publish:
         attributes["event"] = "publish"

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -260,6 +260,11 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
 
     datacite = to_datacite(meta=meta, validate=True)
 
+    # ``doi`` is Optional on the consolidated ``Dandiset`` but always a ``str`` on a
+    # successfully validated published one (here via ``basic_publishmeta``); narrow it
+    # for the str-typed ``datacite_post`` argument.
+    assert meta.doi is not None
+
     # trying to post datacite
     datacite_post(datacite, meta.doi)
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -35,6 +35,7 @@ from pydantic import (
 )
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
+from typing_extensions import Self
 from zarr_checksum.checksum import InvalidZarrChecksum, ZarrDirectoryDigest
 
 from dandischema.conf import (
@@ -574,15 +575,8 @@ class DandiBaseModel(BaseModel):
     @field_validator("schemaKey")
     @classmethod
     def ensure_schemakey(cls, val: str) -> str:
-        tempval = val
-        if "Published" in cls.__name__:
-            tempval = "Published" + tempval
-        elif "BareAsset" == cls.__name__:
-            tempval = "Bare" + tempval
-        if tempval != cls.__name__:
-            raise ValueError(
-                f"schemaKey {tempval} does not match classname {cls.__name__}"
-            )
+        if val != cls.__name__:
+            raise ValueError(f"schemaKey {val} does not match classname {cls.__name__}")
         return val
 
     @classmethod
@@ -1756,6 +1750,40 @@ class Dandiset(CommonModel):
 
     version: str = Field(json_schema_extra={"nskey": "schema", "readOnly": True})
 
+    # Publication-related fields. A non-``None`` ``datePublished`` marks the
+    # record as published; ``check_publication_status`` enforces the cross-field
+    # rules (which of these are then required vs. must be absent).
+    url: Optional[AnyHttpUrl] = Field(
+        None,
+        description="Permalink to the Dandiset.",
+        json_schema_extra={"readOnly": True, "nskey": "schema"},
+    )
+    doi: Optional[str] = Field(
+        None,
+        title="DOI",
+        pattern=DANDI_DOI_PATTERN,
+        json_schema_extra={"readOnly": True, "nskey": DANDI_NSKEY},
+    )
+    """The DOI of the published Dandiset.
+
+    The empty string indicates that there is no DOI for the published Dandiset;
+    it is set automatically for a published Dandiset on a DANDI instance with no
+    configured DOI prefix.
+    """
+    publishedBy: Optional[Union[AnyHttpUrl, PublishActivity]] = Field(
+        None,
+        description="The URL should contain the provenance of the publishing process.",
+        json_schema_extra={"readOnly": True, "nskey": DANDI_NSKEY},
+    )
+    datePublished: Optional[datetime] = Field(
+        None, json_schema_extra={"readOnly": True, "nskey": "schema"}
+    )
+    releaseNotes: Optional[str] = Field(
+        None,
+        description="The description of the release",
+        json_schema_extra={"readOnly": True, "nskey": "schema"},
+    )
+
     wasGeneratedBy: Optional[Sequence[Project]] = Field(
         None,
         title="Associated projects",
@@ -1772,6 +1800,54 @@ class Dandiset(CommonModel):
         "rdfs:label": "Information about the dataset",
         "nskey": DANDI_NSKEY,
     }
+
+    @model_validator(mode="after")
+    def check_publication_status(self) -> Self:
+        """Enforce publication coherence keyed on ``datePublished``.
+
+        A non-``None`` ``datePublished`` marks the record as published and
+        triggers the published-Dandiset requirements; otherwise the publication-only
+        fields must be absent.
+        """
+        errors = []
+        if self.datePublished is None:
+            errors += [
+                f"{name} is not allowed unless datePublished is set"
+                for name in ("doi", "publishedBy", "releaseNotes")
+                if getattr(self, name) is not None
+            ]
+        else:
+            if self.publishedBy is None:
+                errors.append("publishedBy is required for a published Dandiset")
+            if self.url is None:
+                errors.append("url is required for a published Dandiset")
+            elif not re.match(PUBLISHED_VERSION_URL_PATTERN, str(self.url)):
+                errors.append(
+                    f'url does not match regex "{PUBLISHED_VERSION_URL_PATTERN}"'
+                )
+            # Stricter than the ``id`` field pattern, which also accepts
+            # ``/draft`` and a lowercase prefix; only a published version id
+            # passes here.
+            if not re.match(DANDI_PUBID_PATTERN, self.id):
+                errors.append(
+                    f'id "{self.id}" does not match the published-Dandiset pattern '
+                    f'"{DANDI_PUBID_PATTERN}"'
+                )
+            if (
+                self.assetsSummary.numberOfBytes == 0
+                or self.assetsSummary.numberOfFiles == 0
+            ):
+                errors.append(
+                    "A Dandiset containing no files or zero bytes is not publishable"
+                )
+            if self.doi is None:
+                if _INSTANCE_CONFIG.doi_prefix is None:
+                    self.doi = ""
+                else:
+                    errors.append("doi is required for a published Dandiset")
+        if errors:
+            raise ValueError("; ".join(errors))
+        return self
 
 
 class BareAsset(CommonModel):
@@ -1845,9 +1921,8 @@ class BareAsset(CommonModel):
         json_schema_extra={"nskey": "prov"},
     )
 
-    # Bare asset is to be just Asset.
-    schemaKey: Literal["Asset"] = Field(
-        "Asset", validate_default=True, json_schema_extra={"readOnly": True}
+    schemaKey: Literal["BareAsset"] = Field(
+        "BareAsset", validate_default=True, json_schema_extra={"readOnly": True}
     )
 
     _ldmeta = {
@@ -1898,6 +1973,10 @@ class BareAsset(CommonModel):
 class Asset(BareAsset):
     """Metadata used to describe an asset on the server."""
 
+    # A non-``None`` ``datePublished`` marks the asset as published, which
+    # additionally requires ``publishedBy``, a published-asset ``id``, and (for a
+    # non-zarr asset) a ``sha2_256`` digest; see ``check_publication_status``.
+
     # all of the following are set by server
     id: str = Field(
         json_schema_extra={"readOnly": True}, description="Uniform resource identifier."
@@ -1907,102 +1986,64 @@ class Asset(BareAsset):
         json_schema_extra={"readOnly": True, "nskey": "schema"}
     )
 
-
-class Publishable(DandiBaseModel):
-    publishedBy: Union[AnyHttpUrl, PublishActivity] = Field(
+    # Publication-related fields. Present only on a published asset, i.e. when
+    # ``datePublished`` is set.
+    publishedBy: Optional[Union[AnyHttpUrl, PublishActivity]] = Field(
+        None,
         description="The URL should contain the provenance of the publishing process.",
         json_schema_extra={"readOnly": True, "nskey": DANDI_NSKEY},
     )
-    datePublished: datetime = Field(
-        json_schema_extra={"readOnly": True, "nskey": "schema"}
-    )
-    schemaKey: Literal["Publishable", "Dandiset", "Asset"] = Field(
-        "Publishable", validate_default=True, json_schema_extra={"readOnly": True}
+    datePublished: Optional[datetime] = Field(
+        None, json_schema_extra={"readOnly": True, "nskey": "schema"}
     )
 
-
-_doi_field_kwargs: dict[str, Any] = {
-    "title": "DOI",
-    "pattern": DANDI_DOI_PATTERN,
-    "json_schema_extra": {"readOnly": True, "nskey": DANDI_NSKEY},
-}
-if _INSTANCE_CONFIG.doi_prefix is None:
-    _doi_field_kwargs["default"] = ""
-
-
-class PublishedDandiset(Dandiset, Publishable):
-    id: str = Field(
-        description="Uniform resource identifier.",
-        pattern=DANDI_PUBID_PATTERN,
-        json_schema_extra={"readOnly": True},
-    )
-    doi: str = Field(**_doi_field_kwargs)
-    """
-    The DOI of the published Dandiset
-
-    The value of the empty string indicates that there is no DOI for the published
-    Dandiset.
-    """
-
-    url: AnyHttpUrl = Field(
-        description="Permalink to the Dandiset.",
-        json_schema_extra={"readOnly": True, "nskey": "schema"},
-    )
-    releaseNotes: Optional[str] = Field(
-        None,
-        description="The description of the release",
-        json_schema_extra={"readOnly": True, "nskey": "schema"},
-    )
-
-    schemaKey: Literal["Dandiset"] = Field(
-        "Dandiset", validate_default=True, json_schema_extra={"readOnly": True}
-    )
-
-    @field_validator("assetsSummary")
-    @classmethod
-    def check_filesbytes(cls, values: AssetsSummary) -> AssetsSummary:
-        if values.numberOfBytes == 0 or values.numberOfFiles == 0:
-            raise ValueError(
-                "A Dandiset containing no files or zero bytes is not publishable"
-            )
-        return values
-
-    @field_validator("url")
-    @classmethod
-    def check_url(cls, url: AnyHttpUrl) -> AnyHttpUrl:
-        if not re.match(PUBLISHED_VERSION_URL_PATTERN, str(url)):
-            raise ValueError(
-                f'string does not match regex "{PUBLISHED_VERSION_URL_PATTERN}"'
-            )
-        return url
-
-
-class PublishedAsset(Asset, Publishable):
-    id: str = Field(
-        description="Uniform resource identifier.",
-        pattern=ASSET_UUID_PATTERN,
-        json_schema_extra={"readOnly": True},
-    )
-
-    schemaKey: Literal["Asset"] = Field(
+    # mypy flags the narrowed Literal as an incompatible override of
+    # BareAsset's, but pydantic allows it and ensure_schemakey pins each
+    # instance to its class name at runtime.
+    schemaKey: Literal["Asset"] = Field(  # type: ignore[assignment]
         "Asset", validate_default=True, json_schema_extra={"readOnly": True}
     )
 
-    @field_validator("digest")
-    @classmethod
-    def digest_sha256check(
-        cls, v: Dict[DigestType, str], info: ValidationInfo
-    ) -> Dict[DigestType, str]:
-        values = info.data
-        if values.get("encodingFormat") != "application/x-zarr":
-            if DigestType.sha2_256 not in v:
-                raise ValueError("A non-zarr asset must have a sha2_256.")
-            digest = v[DigestType.sha2_256]
-            if not re.fullmatch(SHA256_PATTERN, digest):
-                raise ValueError(
-                    f"Digest must have an appropriate sha2_256 value. Got {digest}"
+    @model_validator(mode="after")
+    def check_publication_status(self) -> Self:
+        """Enforce publication coherence keyed on ``datePublished``.
+
+        A non-``None`` ``datePublished`` marks the asset as published and
+        triggers the published-asset requirements; otherwise ``publishedBy``
+        must be absent.
+        """
+        errors = []
+        if self.datePublished is None:
+            if self.publishedBy is not None:
+                errors.append("publishedBy is not allowed unless datePublished is set")
+        else:
+            if self.publishedBy is None:
+                errors.append("publishedBy is required for a published asset")
+            if not re.match(ASSET_UUID_PATTERN, self.id):
+                errors.append(
+                    f'id "{self.id}" does not match the published-asset pattern '
+                    f'"{ASSET_UUID_PATTERN}"'
                 )
-        return v
+            if self.encodingFormat != "application/x-zarr":
+                if DigestType.sha2_256 not in self.digest:
+                    errors.append("A non-zarr asset must have a sha2_256.")
+                elif not re.fullmatch(SHA256_PATTERN, self.digest[DigestType.sha2_256]):
+                    errors.append(
+                        "Digest must have an appropriate sha2_256 value. "
+                        f"Got {self.digest[DigestType.sha2_256]}"
+                    )
+        if errors:
+            raise ValueError("; ".join(errors))
+        return self
+
+
+# ``PublishedDandiset`` and ``PublishedAsset`` were consolidated into
+# ``Dandiset`` and ``Asset`` respectively: a record is "published" when its
+# ``datePublished`` is set (see each class's ``check_publication_status``).
+# These names are kept as deprecated aliases for backward compatibility and
+# will be removed in a future release.
+PublishedDandiset = Dandiset
+PublishedAsset = Asset
 
 
 def get_schema_version() -> str:

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -34,7 +34,8 @@ from pydantic import (
     model_validator,
 )
 from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema
+from pydantic_core import CoreSchema, InitErrorDetails
+from pydantic_core import ValidationError as _CoreValidationError
 from typing_extensions import Self
 from zarr_checksum.checksum import InvalidZarrChecksum, ZarrDirectoryDigest
 
@@ -1751,8 +1752,7 @@ class Dandiset(CommonModel):
     version: str = Field(json_schema_extra={"nskey": "schema", "readOnly": True})
 
     # Publication-related fields. A non-``None`` ``datePublished`` marks the
-    # record as published; ``check_publication_status`` enforces the cross-field
-    # rules (which of these are then required vs. must be absent).
+    # record as published; ``check_publication_status`` enforces the rules.
     url: Optional[AnyHttpUrl] = Field(
         None,
         description="Permalink to the Dandiset.",
@@ -1807,46 +1807,59 @@ class Dandiset(CommonModel):
 
         A non-``None`` ``datePublished`` marks the record as published and
         triggers the published-Dandiset requirements; otherwise the publication-only
-        fields must be absent.
+        fields must be absent. Each violation is reported against its own field.
         """
-        errors = []
+        line_errors: list[InitErrorDetails] = []
+
+        def err(field: str, msg: str) -> None:
+            line_errors.append(
+                InitErrorDetails(
+                    type="value_error",
+                    loc=(field,),
+                    input=getattr(self, field),
+                    ctx={"error": msg},
+                )
+            )
+
         if self.datePublished is None:
-            errors += [
-                f"{name} is not allowed unless datePublished is set"
-                for name in ("doi", "publishedBy", "releaseNotes")
-                if getattr(self, name) is not None
-            ]
+            for name in ("doi", "publishedBy", "releaseNotes"):
+                if getattr(self, name) is not None:
+                    err(name, f"{name} is not allowed unless datePublished is set")
         else:
             if self.publishedBy is None:
-                errors.append("publishedBy is required for a published Dandiset")
+                err("publishedBy", "publishedBy is required for a published Dandiset")
             if self.url is None:
-                errors.append("url is required for a published Dandiset")
+                err("url", "url is required for a published Dandiset")
             elif not re.match(PUBLISHED_VERSION_URL_PATTERN, str(self.url)):
-                errors.append(
-                    f'url does not match regex "{PUBLISHED_VERSION_URL_PATTERN}"'
+                err(
+                    "url", f'url does not match regex "{PUBLISHED_VERSION_URL_PATTERN}"'
                 )
             # Stricter than the ``id`` field pattern, which also accepts
             # ``/draft`` and a lowercase prefix; only a published version id
             # passes here.
             if not re.match(DANDI_PUBID_PATTERN, self.id):
-                errors.append(
+                err(
+                    "id",
                     f'id "{self.id}" does not match the published-Dandiset pattern '
-                    f'"{DANDI_PUBID_PATTERN}"'
+                    f'"{DANDI_PUBID_PATTERN}"',
                 )
             if (
                 self.assetsSummary.numberOfBytes == 0
                 or self.assetsSummary.numberOfFiles == 0
             ):
-                errors.append(
-                    "A Dandiset containing no files or zero bytes is not publishable"
+                err(
+                    "assetsSummary",
+                    "A Dandiset containing no files or zero bytes is not publishable",
                 )
             if self.doi is None:
                 if _INSTANCE_CONFIG.doi_prefix is None:
                     self.doi = ""
                 else:
-                    errors.append("doi is required for a published Dandiset")
-        if errors:
-            raise ValueError("; ".join(errors))
+                    err("doi", "doi is required for a published Dandiset")
+        if line_errors:
+            raise _CoreValidationError.from_exception_data(
+                self.__class__.__name__, line_errors
+            )
         return self
 
 
@@ -1973,9 +1986,8 @@ class BareAsset(CommonModel):
 class Asset(BareAsset):
     """Metadata used to describe an asset on the server."""
 
-    # A non-``None`` ``datePublished`` marks the asset as published, which
-    # additionally requires ``publishedBy``, a published-asset ``id``, and (for a
-    # non-zarr asset) a ``sha2_256`` digest; see ``check_publication_status``.
+    # A non-``None`` ``datePublished`` marks the asset as published; see
+    # ``check_publication_status`` for the rules that then apply.
 
     # all of the following are set by server
     id: str = Field(
@@ -2010,30 +2022,50 @@ class Asset(BareAsset):
 
         A non-``None`` ``datePublished`` marks the asset as published and
         triggers the published-asset requirements; otherwise ``publishedBy``
-        must be absent.
+        must be absent. Each violation is reported against its own field.
         """
-        errors = []
+        line_errors: list[InitErrorDetails] = []
+
+        def err(field: str, msg: str) -> None:
+            line_errors.append(
+                InitErrorDetails(
+                    type="value_error",
+                    loc=(field,),
+                    input=getattr(self, field),
+                    ctx={"error": msg},
+                )
+            )
+
         if self.datePublished is None:
             if self.publishedBy is not None:
-                errors.append("publishedBy is not allowed unless datePublished is set")
+                err(
+                    "publishedBy",
+                    "publishedBy is not allowed unless datePublished is set",
+                )
         else:
             if self.publishedBy is None:
-                errors.append("publishedBy is required for a published asset")
+                err("publishedBy", "publishedBy is required for a published asset")
             if not re.match(ASSET_UUID_PATTERN, self.id):
-                errors.append(
+                err(
+                    "id",
                     f'id "{self.id}" does not match the published-asset pattern '
-                    f'"{ASSET_UUID_PATTERN}"'
+                    f'"{ASSET_UUID_PATTERN}"',
                 )
             if self.encodingFormat != "application/x-zarr":
                 if DigestType.sha2_256 not in self.digest:
-                    errors.append("A non-zarr asset must have a sha2_256.")
-                elif not re.fullmatch(SHA256_PATTERN, self.digest[DigestType.sha2_256]):
-                    errors.append(
-                        "Digest must have an appropriate sha2_256 value. "
-                        f"Got {self.digest[DigestType.sha2_256]}"
-                    )
-        if errors:
-            raise ValueError("; ".join(errors))
+                    err("digest", "A non-zarr asset must have a sha2_256.")
+                else:
+                    sha2_256_digest = self.digest[DigestType.sha2_256]
+                    if not re.fullmatch(SHA256_PATTERN, sha2_256_digest):
+                        err(
+                            "digest",
+                            "Digest must have an appropriate sha2_256 value. "
+                            f"Got {sha2_256_digest}",
+                        )
+        if line_errors:
+            raise _CoreValidationError.from_exception_data(
+                self.__class__.__name__, line_errors
+            )
         return self
 
 

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -13,7 +13,6 @@ from dandischema.utils import TransitionalGenerateJsonSchema
 
 from .utils import (
     DANDISET_METADATA_DIR,
-    DOI_PREFIX,
     INSTANCE_NAME,
     METADATA_DIR,
     skipif_instance_name_not_dandi,
@@ -130,27 +129,23 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             },
         ),
         (
+            # ``PublishedDandiset`` is now an alias of ``Dandiset``; its
+            # publication-only fields are optional (gated on ``datePublished``),
+            # so an incomplete instance reports the same missing fields as
+            # ``Dandiset``.
             {"schemaKey": "Dandiset"},
             "PublishedDandiset",
             {
-                e
-                for e in [
-                    "assetsSummary",
-                    "citation",
-                    "contributor",
-                    "datePublished",
-                    "description",
-                    "doi",
-                    "id",
-                    "identifier",
-                    "license",
-                    "manifestLocation",
-                    "name",
-                    "publishedBy",
-                    "url",
-                    "version",
-                ]
-                if DOI_PREFIX is not None or e != "doi"
+                "assetsSummary",
+                "citation",
+                "contributor",
+                "description",
+                "id",
+                "identifier",
+                "license",
+                "manifestLocation",
+                "name",
+                "version",
             },
         ),
         (
@@ -160,24 +155,16 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             },
             "PublishedDandiset",
             {
-                e
-                for e in [
-                    "assetsSummary",
-                    "citation",
-                    "contributor",
-                    "datePublished",
-                    "description",
-                    "doi",
-                    "id",
-                    "identifier",
-                    "license",
-                    "manifestLocation",
-                    "name",
-                    "publishedBy",
-                    "url",
-                    "version",
-                ]
-                if DOI_PREFIX is not None or e != "doi"
+                "assetsSummary",
+                "citation",
+                "contributor",
+                "description",
+                "id",
+                "identifier",
+                "license",
+                "manifestLocation",
+                "name",
+                "version",
             },
         ),
         (
@@ -194,23 +181,15 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             },
             "PublishedDandiset",
             {
-                e
-                for e in [
-                    "assetsSummary",
-                    "citation",
-                    "datePublished",
-                    "description",
-                    "doi",
-                    "id",
-                    "identifier",
-                    "license",
-                    "manifestLocation",
-                    "name",
-                    "publishedBy",
-                    "url",
-                    "version",
-                ]
-                if DOI_PREFIX is not None or e != "doi"
+                "assetsSummary",
+                "citation",
+                "description",
+                "id",
+                "identifier",
+                "license",
+                "manifestLocation",
+                "name",
+                "version",
             },
         ),
         (
@@ -235,12 +214,13 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             {"contentSize", "encodingFormat", "id", "identifier", "path", "contentUrl"},
         ),
         (
+            # ``PublishedAsset`` is now an alias of ``Asset``; ``publishedBy`` and
+            # ``datePublished`` are optional (gated on ``datePublished``), so an
+            # incomplete instance reports the same missing fields as ``Asset``.
             {"schemaKey": "Asset"},
             "PublishedAsset",
             {
-                "datePublished",
                 "contentSize",
-                "publishedBy",
                 "encodingFormat",
                 "id",
                 "identifier",
@@ -250,15 +230,15 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             },
         ),
         (
+            # A sha2_256-only digest fails ``digest_check`` (a non-zarr asset must
+            # have a dandi-etag), so ``digest`` is reported too.
             {
                 "schemaKey": "Asset",
                 "digest": {"dandi:sha2-256": sha256(b"test").hexdigest()},
             },
             "PublishedAsset",
             {
-                "datePublished",
                 "contentSize",
-                "publishedBy",
                 "encodingFormat",
                 "id",
                 "identifier",
@@ -268,20 +248,21 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             },
         ),
         (
+            # A valid etag digest passes ``digest_check``; the sha2_256
+            # requirement is gated on ``datePublished`` and the model validator
+            # never runs here (required fields are missing), so ``digest`` is not
+            # reported.
             {
                 "schemaKey": "Asset",
                 "digest": {"dandi:dandi-etag": md5(b"test").hexdigest() + "-1"},
             },
             "PublishedAsset",
             {
-                "datePublished",
                 "contentSize",
-                "publishedBy",
                 "encodingFormat",
                 "id",
                 "identifier",
                 "path",
-                "digest",
                 "contentUrl",
             },
         ),
@@ -295,9 +276,7 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
             },
             "PublishedAsset",
             {
-                "datePublished",
                 "contentSize",
-                "publishedBy",
                 "encodingFormat",
                 "id",
                 "identifier",

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -471,20 +471,21 @@ def test_dandimeta_1(base_dandiset_metadata: dict[str, Any]) -> None:
 
     # Setting datePublished marks the record published and triggers the
     # publish-only requirements. The draft id/url/assetsSummary and the missing
-    # publishedBy/doi are reported together in a single model-level error.
+    # publishedBy/doi are each reported against their own field.
     publishing = dict(base_dandiset_metadata, datePublished="2021-01-01T00:00:00+00:00")
     with pytest.raises(ValidationError) as exc:
         Dandiset(**publishing)
-    assert len(exc.value.errors()) == 1
-    msg = exc.value.errors()[0]["msg"]
-    for expected in [
-        "publishedBy is required for a published Dandiset",
-        "url does not match regex",
-        "does not match the published-Dandiset pattern",
-        "A Dandiset containing no files or zero bytes is not publishable",
-        "doi is required for a published Dandiset",
-    ]:
-        assert expected in msg
+    by_field = {err["loc"][0]: err["msg"] for err in exc.value.errors()}
+    expected = {
+        "publishedBy": "publishedBy is required for a published Dandiset",
+        "url": "url does not match regex",
+        "id": "does not match the published-Dandiset pattern",
+        "assetsSummary": "A Dandiset containing no files or zero bytes is not publishable",
+        "doi": "doi is required for a published Dandiset",
+    }
+    assert set(by_field) == set(expected)
+    for field, substr in expected.items():
+        assert substr in by_field[field]
 
     # after adding basic meta required to publish: doi, datePublished, publishedBy, assetsSummary,
     # so PublishedDandiset should work

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -1,7 +1,6 @@
-from collections import namedtuple
 from enum import Enum
 from inspect import isclass
-from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Type, Union, cast
 
 import anys
 import pydantic
@@ -13,7 +12,6 @@ from dandischema.conf import get_instance_config
 from .utils import DOI_PREFIX, INSTANCE_NAME, basic_publishmeta, skipif_no_doi_prefix
 from .. import models
 from ..models import (
-    DANDI_INSTANCE_URL_PATTERN,
     DANDI_NSKEY,
     AccessRequirements,
     AccessType,
@@ -131,6 +129,17 @@ def test_asset() -> None:
 
 
 def test_asset_digest() -> None:
+    # Fields needed (beyond the bare asset fields) to make an instance a
+    # complete, published ``Asset`` so the ``datePublished``-gated checks (e.g.
+    # the sha2_256 requirement, formerly on ``PublishedAsset``) actually run.
+    pub_extra: Dict[str, Any] = {
+        "id": "dandiasset:6668d37f-e842-4b73-8c20-082a1dd0d31a",
+        "identifier": "6668d37f-e842-4b73-8c20-082a1dd0d31a",
+        "contentUrl": ["https://example.com/asset"],
+        "publishedBy": "https://example.com/dandi/publish",
+        "datePublished": "2021-01-01T00:00:00+00:00",
+    }
+
     with pytest.raises(pydantic.ValidationError) as exc:
         models.BareAsset(
             contentSize=100, encodingFormat="nwb", digest={"sha1": ""}, path="/"
@@ -159,11 +168,12 @@ def test_asset_digest() -> None:
         contentSize=100, encodingFormat="nwb", digest=digest_model, path="/"
     )
     with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
+        models.Asset(
             contentSize=100,
             encodingFormat="nwb",
             digest={models.DigestType.dandi_etag: digest, "sha1": ""},
             path="/",
+            **pub_extra,
         )
 
     # Assert validation failed at the `digest` attribute because the provided dictionary
@@ -178,8 +188,12 @@ def test_asset_digest() -> None:
         models.DigestType.sha2_256: 63 * "a",
     }
     with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
-            contentSize=100, encodingFormat="nwb", digest=digest_model, path="/"
+        models.Asset(
+            contentSize=100,
+            encodingFormat="nwb",
+            digest=digest_model,
+            path="/",
+            **pub_extra,
         )
     assert any(
         "Digest must have an appropriate sha2_256 value." in el["msg"]
@@ -189,20 +203,24 @@ def test_asset_digest() -> None:
         models.DigestType.dandi_etag: digest,
         models.DigestType.sha2_256: 64 * "a",
     }
-    with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
-            contentSize=100, encodingFormat="nwb", digest=digest_model, path="/"
-        )
-    assert not any(
-        "Digest must have an appropriate dandi-etag value." in el["msg"]
-        for el in exc.value.errors()
+    # A complete published asset with a valid etag and sha2_256 is valid.
+    models.Asset(
+        contentSize=100,
+        encodingFormat="nwb",
+        digest=digest_model,
+        path="/",
+        **pub_extra,
     )
     digest_model = {
         models.DigestType.dandi_etag: digest,
     }
     with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
-            contentSize=100, encodingFormat="nwb", digest=digest_model, path="/"
+        models.Asset(
+            contentSize=100,
+            encodingFormat="nwb",
+            digest=digest_model,
+            path="/",
+            **pub_extra,
         )
     assert any(
         "A non-zarr asset must have a sha2_256." in el["msg"]
@@ -235,16 +253,18 @@ def test_asset_digest() -> None:
         "contentSize 100 is not equal to the checksum size 42." in val
         for val in set(el["msg"] for el in exc.value.errors())
     )
+    # A complete published zarr asset (valid zarr checksum, no sha2_256) is
+    # valid: zarr assets are exempt from the published-asset sha2_256
+    # requirement that applies to non-zarr assets.
     digest = f"{32 * 'a'}-1--100"
     digest_model = {models.DigestType.dandi_zarr_checksum: digest}
-    with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
-            contentSize=100,
-            encodingFormat="application/x-zarr",
-            digest=digest_model,
-            path="/",
-        )
-    assert all(err["type"] == "missing" for err in exc.value.errors())
+    models.Asset(
+        contentSize=100,
+        encodingFormat="application/x-zarr",
+        digest=digest_model,
+        path="/",
+        **pub_extra,
+    )
     digest_model = {
         models.DigestType.dandi_zarr_checksum: digest,
         models.DigestType.dandi_etag: digest + "-1",
@@ -261,11 +281,12 @@ def test_asset_digest() -> None:
         for val in set(el["msg"] for el in exc.value.errors())
     )
     with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
+        models.Asset(
             contentSize=100,
             encodingFormat="application/x-zarr",
             digest=digest_model,
             path="/",
+            **pub_extra,
         )
     assert any(
         "Digest cannot have both etag and zarr checksums." in val
@@ -284,11 +305,12 @@ def test_asset_digest() -> None:
         for val in set(el["msg"] for el in exc.value.errors())
     )
     with pytest.raises(pydantic.ValidationError) as exc:
-        models.PublishedAsset(  # type: ignore[call-arg]
+        models.Asset(
             contentSize=100,
             encodingFormat="application/x-zarr",
             digest=digest_model,
             path="/",
+            **pub_extra,
         )
     assert any(
         "A zarr asset must have a zarr checksum." in val
@@ -442,54 +464,27 @@ def test_dandimeta_1(base_dandiset_metadata: dict[str, Any]) -> None:
 
     assert DOI_PREFIX is not None
 
-    # should work for Dandiset but PublishedDandiset should raise an error
+    # The base metadata is a valid draft (no datePublished), so it validates as a
+    # Dandiset (and, since PublishedDandiset is now an alias of Dandiset, as that
+    # too).
     Dandiset(**base_dandiset_metadata)
+
+    # Setting datePublished marks the record published and triggers the
+    # publish-only requirements. The draft id/url/assetsSummary and the missing
+    # publishedBy/doi are reported together in a single model-level error.
+    publishing = dict(base_dandiset_metadata, datePublished="2021-01-01T00:00:00+00:00")
     with pytest.raises(ValidationError) as exc:
-        PublishedDandiset(**base_dandiset_metadata)
-
-    ErrDetail = namedtuple("ErrDetail", ["type", "msg"])
-
-    # Expected errors keyed by location of the respective error
-    # Note: Pydantic generated error messages are not provided for they are not in our
-    #       control, and the error type should be indicative enough.
-    expected_errors: Dict[Tuple[Union[int, str], ...], ErrDetail] = {
-        ("id",): ErrDetail(type="string_pattern_mismatch", msg=None),
-        ("publishedBy",): ErrDetail(type="missing", msg=None),
-        ("datePublished",): ErrDetail(type="missing", msg=None),
-        ("url",): ErrDetail(
-            type="value_error",
-            msg="Value error, string does not match regex "
-            f'"^{DANDI_INSTANCE_URL_PATTERN}/dandiset/'
-            '\\d{6}/\\d+\\.\\d+\\.\\d+$"',
-        ),
-        ("assetsSummary",): ErrDetail(
-            type="value_error",
-            msg="Value error, "
-            "A Dandiset containing no files or zero bytes is not publishable",
-        ),
-        ("doi",): ErrDetail(type="missing", msg=None),
-    }
-
-    assert len(exc.value.errors()) == len(expected_errors)
-    for err in exc.value.errors():
-        err_loc = err["loc"]
-        assert err_loc in expected_errors
-
-        assert err["type"] == expected_errors[err_loc].type
-        if expected_errors[err_loc].msg is not None:
-            assert err["msg"] == expected_errors[err_loc].msg
-
-    assert set(loc[0] if (loc := el["loc"]) else None for el in exc.value.errors()) == {
-        e
-        for e in [
-            "assetsSummary",
-            "datePublished",
-            "publishedBy",
-            "doi",
-            "url",
-            "id",
-        ]
-    }
+        Dandiset(**publishing)
+    assert len(exc.value.errors()) == 1
+    msg = exc.value.errors()[0]["msg"]
+    for expected in [
+        "publishedBy is required for a published Dandiset",
+        "url does not match regex",
+        "does not match the published-Dandiset pattern",
+        "A Dandiset containing no files or zero bytes is not publishable",
+        "doi is required for a published Dandiset",
+    ]:
+        assert expected in msg
 
     # after adding basic meta required to publish: doi, datePublished, publishedBy, assetsSummary,
     # so PublishedDandiset should work
@@ -518,9 +513,82 @@ def test_dandimeta_1(base_dandiset_metadata: dict[str, Any]) -> None:
     assert dumped["releaseNotes"] == "Releasing during testing"
 
 
+def test_dandiset_publication_coherence(
+    base_dandiset_metadata: dict[str, Any],
+) -> None:
+    """A draft Dandiset (no datePublished) must not carry publication-only fields."""
+    Dandiset(**base_dandiset_metadata)  # a valid draft
+
+    draft_with_pub_field = dict(
+        base_dandiset_metadata,
+        publishedBy="https://example.com/dandi/publish",
+    )
+    with pytest.raises(ValidationError) as exc:
+        Dandiset(**draft_with_pub_field)
+    assert (
+        "publishedBy is not allowed unless datePublished is set"
+        in exc.value.errors()[0]["msg"]
+    )
+
+
+def test_asset_publication_coherence() -> None:
+    """A non-``None`` ``datePublished`` gates the published-asset requirements."""
+    valid_etag = 32 * "a" + "-1"
+    valid_sha256 = 64 * "a"
+    server_fields: Dict[str, Any] = {
+        "id": "dandiasset:6668d37f-e842-4b73-8c20-082a1dd0d31a",
+        "identifier": "6668d37f-e842-4b73-8c20-082a1dd0d31a",
+        "contentUrl": ["https://example.com/asset"],
+        "contentSize": 100,
+        "encodingFormat": "application/x-nwb",
+        "path": "/",
+    }
+
+    # An unpublished server asset needs only an etag (no sha2_256 required) and
+    # must not carry publishedBy.
+    Asset(**server_fields, digest={DigestType.dandi_etag: valid_etag})
+    with pytest.raises(ValidationError) as exc:
+        Asset(
+            **server_fields,
+            digest={DigestType.dandi_etag: valid_etag},
+            publishedBy="https://example.com/dandi/publish",
+        )
+    assert (
+        "publishedBy is not allowed unless datePublished is set"
+        in exc.value.errors()[0]["msg"]
+    )
+
+    # A complete published asset (publishedBy, a published id and a sha2_256)
+    # validates.
+    Asset(
+        **server_fields,
+        digest={
+            DigestType.dandi_etag: valid_etag,
+            DigestType.sha2_256: valid_sha256,
+        },
+        publishedBy="https://example.com/dandi/publish",
+        datePublished="2021-01-01T00:00:00+00:00",
+    )
+
+    # A published asset whose id is not a published-asset id is rejected.
+    with pytest.raises(ValidationError) as exc:
+        Asset(
+            **{**server_fields, "id": "not-a-dandiasset-id"},
+            digest={
+                DigestType.dandi_etag: valid_etag,
+                DigestType.sha2_256: valid_sha256,
+            },
+            publishedBy="https://example.com/dandi/publish",
+            datePublished="2021-01-01T00:00:00+00:00",
+        )
+    assert "does not match the published-asset pattern" in exc.value.errors()[0]["msg"]
+
+
 def test_schemakey() -> None:
+    # ``PublishedAsset``/``PublishedDandiset`` are deprecated aliases of
+    # ``Asset``/``Dandiset``, so under their alias names ``dir(models)`` yields
+    # the consolidated class whose ``schemaKey`` default is the base class name.
     typemap = {
-        "BareAsset": "Asset",
         "PublishedAsset": "Asset",
         "PublishedDandiset": "Dandiset",
     }
@@ -578,6 +646,13 @@ def test_duplicate_classes() -> None:
                 "AssetsSummary",
             }:
                 return
+            # ``publishedBy`` lives on both ``Asset`` and ``Dandiset`` since the
+            # shared ``Publishable`` mixin was removed during consolidation.
+            if qname == "dandi:publishedBy" and {t.__name__, klass.__name__} == {
+                "Asset",
+                "Dandiset",
+            }:
+                return
             raise ValueError(f"{qname},{klass} already exists {qnames[qname]}")
         qnames[qname] = klass
 
@@ -614,7 +689,6 @@ def test_properties_mismatch() -> None:
     modelnames.remove("DandiBaseModel")
     modelnames.remove("CommonModel")
     modelnames.remove("Contributor")
-    modelnames.remove("Publishable")
     for val in modelnames:
         klass = getattr(models, val)
         if not isclass(klass) or not issubclass(klass, pydantic.BaseModel):


### PR DESCRIPTION
## Summary

Make every model class's `schemaKey` value equal its class name, so that an eventual LinkML translation can use `schemaKey` as its type designator (`designates_type`). Three classes violated this (`BareAsset` → `"Asset"`, `PublishedAsset` → `"Asset"`, `PublishedDandiset` → `"Dandiset"`), and fixing them takes two distinct changes:

1. **Consolidate the publication-specific variants into their base classes:** `PublishedDandiset` merges into `Dandiset` and `PublishedAsset` into `Asset`. Publication requirements now fire via a `datePublished`-gated validator instead of separate classes.
2. **Align `BareAsset.schemaKey` to `"BareAsset"`**

Stored `schemaKey` values in archive data are unchanged, and the old names remain as deprecated aliases so `dandi-cli`/`dandi-archive` imports keep working. Adopting this release does, however, require one lockstep `dandi-cli` change (see Prerequisites).

`DANDI_SCHEMA_VERSION` is also bumped to `0.8.0`, which is due independently of the model consolidation: the schemas generated from `master` already differ from the published `0.7.0`, and this PR changes all four of them further. A summary of the diff against the published `0.7.0`, and of why none of it is breaking for existing metadata, is in https://github.com/dandi/dandi-schema/pull/419#issuecomment-5086656768.

## Prerequisites (merge first)

- **dandi/dandi-schema#422** — removes the `missing_ok` parameter of `metadata.validate`. That parameter is never really used, and its feature never actually worked as intended (see #422 for details); merging it first frees this PR from having to keep that behavior "working" while it reshapes the validation errors.
- **dandi/dandi-cli#1886** — set `schemaKey = "Asset"` on bare asset metadata at upload, since `BareAsset.schemaKey` is now `"BareAsset"` and the server does not normalize it.

<details>
<summary>What changed in <code>dandischema/models.py</code></summary>

- **Merge `PublishedDandiset` → `Dandiset`, `PublishedAsset` → `Asset`.** Publication-only fields (`doi`, `publishedBy`, `datePublished`, `releaseNotes` on `Dandiset`; `publishedBy`, `datePublished` on `Asset`) become optional, and the publication requirements move into a `datePublished`-gated `check_publication_status` model validator:
  - `datePublished` is `None` (draft) → publication-only fields must be absent;
  - `datePublished` set (published) → enforce the former `Published*` rules (`publishedBy`/`url`/`doi` presence, stricter `id`/`url` patterns, `check_filesbytes`, `digest_sha256check`).

  dandi-archive injects `datePublished` before validating, so the gated checks fire exactly as the `Published*` classes did.
- **Per-field validation errors.** The publication validator accumulates all violations and raises them via `pydantic_core.ValidationError.from_exception_data(...)`, so each error carries its own field `loc` (e.g. `('assetsSummary',)`) plus the usual `"Value error, …"` message — rather than one model-level error with an empty `loc`.
- **Keep `BareAsset`** (`Asset` still inherits it) with `schemaKey: Literal["BareAsset"]`; `Asset` overrides it to `Literal["Asset"]` (a localized `# type: ignore[assignment]` covers the narrowed override), and `ensure_schemakey` pins each instance's value to its class name.
- **Remove the `Publishable` mixin**; add `PublishedDandiset`/`PublishedAsset` as deprecated aliases.
- **Simplify `ensure_schemakey`** to a plain `schemaKey == class-name` check.
- `to_datacite` asserts the published precondition (`datePublished` set) the `PublishedDandiset` type used to guarantee.
</details>

<details>
<summary>What changed outside <code>dandischema/models.py</code></summary>

- **`dandischema/consts.py`:** `DANDI_SCHEMA_VERSION` becomes `0.8.0`, and `"0.7.0"` joins `ALLOWED_INPUT_SCHEMAS` so that metadata stamped with it remains valid input for `migrate()`.

The `tools/api-with-schema.Dockerfile` change that the `test-dandi-cli` results below depend on (adding `ENV UV_NO_SYNC=1` and dropping the undeclared `dev` extra) was split out into dandi/dandi-schema#435 and merged to `master`, so it is no longer part of this PR's diff; this branch inherits it after being rebased onto `master`.
</details>

<details>
<summary>Why gate on <code>datePublished</code> rather than an explicit (context-triggered) validator</summary>

The publish-only checks could instead be triggered explicitly by the caller (e.g. a Pydantic validation-context flag passed by the publish flow) rather than by the presence of `datePublished`. We chose data-driven gating because:

- **It can be expressed in LinkML; an explicit context cannot.** Gating on a real field is a conditional constraint on the data, which is exactly what a LinkML rule expresses (`gen-json-schema` emits it as `if`/`then`). A caller-supplied validation mode has no LinkML equivalent — LinkML describes only the data instance, not how validation is invoked — so it would have to live as hand-written Python forever, outside the source of truth, working against the migration this change is meant to enable.
- **It travels with the data.** The gated checks fire through both `validate()` and direct construction (`Dandiset(**data)` / `model_validate`). A context flag only rides `model_validate(..., context=...)`: the terse `PublishedDandiset(**meta)` form (used by `to_datacite` and in tests) cannot pass one, so it would silently skip the publish checks. Beyond the call-site rewrites that would force, a constructor whose enforcement quietly depends on how it is invoked is a lasting programming hazard.
- **It matches the domain.** `datePublished` present ⟺ published is a real invariant: a draft never carries it, and the archive injects it only when building a publishable version. "Published" is a state of the record, not a mode a caller opts into.
- **Published-ness stays introspectable.** With gating, "is this published?" is just `obj.datePublished is not None`; with a context flag, whether an object was validated as published is ephemeral to the call and recorded nowhere on the object.
</details>

<details>
<summary>Compatibility</summary>

- Generated JSON Schema (verified by before/after diff): draft `Dandiset`/`Asset` gain **only optional, `readOnly`** publication properties — nothing newly required, no pattern tightened — so the dandi-archive Meditor is unaffected (it hides `readOnly` props). The `published-*.json` schemas become the relaxed versions, with publication strictness enforced by the gated validator.
- `published-dandiset.json` and `published-asset.json` are now byte-identical to `dandiset.json` and `asset.json`, because `publish_model_schemata` generates each file from the class named in `SCHEMA_MAP` and `PublishedDandiset`/`PublishedAsset` are now aliases of `Dandiset`/`Asset`.
- The publication requirements no longer appear in the generated JSON Schema at all, since they are conditional on `datePublished` and a flat `required` list cannot express that; the gated validator enforces them instead. That is an acceptable gap for now: the plan is to re-encode these requirements as LinkML rules in the LinkML translation, where `gen-json-schema` emits them as `if`/`then`.
- `PublishedDandiset`/`PublishedAsset`/`BareAsset` imports continue to work in `dandi-cli`/`dandi-archive`.
</details>

## Follow-ups (separate PRs)

- Bump the `dandischema` pin in dandi-archive and dandi-cli once this change is merged and released. Both pin `dandischema`, and `DANDI_SCHEMA_VERSION` must match across the two services, so they need to move to the same release together. This is also what clears the expected `test-dandi-cli` failures described under Test plan.
  - The bump of  `dandischema` in dandi-cli has been implemented in https://github.com/dandi/dandi-cli/pull/1898
  - The bump of  `dandischema` in dandi-archive is being tracked with https://github.com/dandi/dandi-archive/issues/2876
- [x] dandi-archive `_encode_pydantic_error` robustness (dandi/dandi-archive#2851). This PR's per-field errors avoid the empty-`loc` case at the source, but that fix is still worth having as defense-in-depth.
- https://github.com/dandi/dandi-schema/issues/440
## Test plan

- [x] `tox -e py3` (262 passed, 17 skipped — skips are environment-only: no `DOI_PREFIX` / instance name not "DANDI")
- [x] `tox -e lint,typing`
- [x] Generated JSON Schema before/after diff reviewed, and diffed against the published `0.7.0` release in `dandi/schema` (see the comment linked from the Summary)
- [x] Added tests for the `datePublished`-gated publish requirements and the coherence invariant
- [x] Verified against dandi-archive's own CI via the throwaway PR dandi/dandi-archive#2866, which pins `dandischema` to this branch. After this PR was rebased onto `master` (following the dandi/dandi-schema#435 split), that pin was re-resolved to the current tip (`227cdd01`) and the run re-triggered; this box will be checked once the refreshed run passes. The earlier run, against the now-dropped pre-split tip, had the archive's publication-validation suite (`backend-ci`) passing against the consolidated models and both `cli-integration` variants (consolidated-model server against a released-`dandischema` client, on dandi-cli `master` and `release`) passing.

### Expected `test-dandi-cli` failures

Bumping `DANDI_SCHEMA_VERSION` ahead of dandi-archive and dandi-cli leaves integration jobs red: three of them today, and two once dandi/dandi-cli#1894 merges, since the `server` job runs dandi-cli `master` and that PR drops the incidental requirement that both sides carry the same `DANDI_SCHEMA_VERSION`. Each is version skew between the two sides of the test rather than a regression from the model changes, and none can be fixed from this PR; the remaining two clear when both services move to this release.

<details>
<summary>Which jobs fail, and why</summary>

| job | client schema | server schema | outcome |
| --- | --- | --- | --- |
| ubuntu, `client`, dandi-cli `master` | 0.8.0 | 0.7.0 | fail |
| ubuntu, `client`, dandi-cli `release` | 0.8.0 | 0.7.0 | fail |
| ubuntu, `server` | 0.7.0 | 0.8.0 | fail, until dandi/dandi-cli#1894 merges |
| ubuntu, `both` (default and ember-dandi) | 0.8.0 | 0.8.0 | pass |
| macOS and Windows, `client` | 0.8.0 | n/a | pass, no Docker so the server-backed tests are skipped |

- The two `client` jobs install this branch into the client only, so a `0.8.0` client meets the released `0.7.0` server. dandi-cli treats a server that is behind by a MINOR schema version as fatal (`dandi/dandiapi.py:740-747`), so nearly every server-backed test errors with `SchemaVersionError: Server uses older incompatible schema version 0.7.0; client supports 0.8.0`.
- The `server` job is the mirror image: a released client against a `0.8.0` server. Only 5 of 1006 tests fail, all `cli/tests/test_service_scripts.py::test_update_dandiset_from_doi`, because that test builds its expected `schemaVersion` and `@context` from the client's own `DANDI_SCHEMA_VERSION` (`test_service_scripts.py:111-118`) and so expects `0.7.0` where the server emits `0.8.0`. dandi/dandi-cli#1894 fixes that expectation, and since this job runs dandi-cli `master`, it goes green on a re-run once that PR merges.
- The `both` jobs install this branch on both sides and pass, which is the signal that the consolidated models and the new schema version work end to end.

Before the `UV_NO_SYNC=1` fix (added in dandi/dandi-schema#435, now in `master` and inherited here via rebase), the `both` jobs failed exactly like the `client` jobs, and the `server` job passed only because the ineffective override left both sides agreeing on `0.7.0`. Its red status here is a consequence of the override finally working.
</details>


