### PR TITLE
docs: add Integration Tests badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DANDI Schema
 
 [![Tests](https://github.com/dandi/dandi-schema/actions/workflows/test.yml/badge.svg)](https://github.com/dandi/dandi-schema/actions/workflows/test.yml)
+[![Integration Tests](https://github.com/dandi/dandi-schema/actions/workflows/test-dandi-cli.yml/badge.svg)](https://github.com/dandi/dandi-schema/actions/workflows/test-dandi-cli.yml)
 
 `dandi-schema` is a Python library for maintaining and managing DANDI metadata models and schemas.
 


### PR DESCRIPTION
## Summary
- Adds a second CI status badge to the README, labeled "Integration Tests", linking to the `test-dandi-cli.yml` workflow (cross-repo checks against `dandi-cli`).
- Follow-up to #425, which added the first `Tests` badge for `test.yml` but left `test-dandi-cli.yml` unrepresented.

## Test plan
- [x] Verified `test-dandi-cli.yml`'s `name:` and badge URL path match.
- [x] Confirmed the workflow runs on `pull_request` (not just `push` to `master`), so the badge reflects current status, not a stale one.
- [x] Visual check that both badges render correctly side by side once this PR's own CI badge updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)