### PR TITLE
test: fix bugs and tighten checks in `test_duplicate_classes`

### DIFF
--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -572,25 +572,25 @@ def test_duplicate_classes() -> None:
             elif issubclass(t, klass):
                 qnames[qname] = klass
                 return
-            if qname == "dandi:repository" and klass.__name__ in (
+            if qname == "dandi:repository" and {t.__name__, klass.__name__} == {
                 "Resource",
                 "CommonModel",
-            ):
+            }:
                 return
-            if qname == "dandi:relation" and klass.__name__ in (
+            if qname == "dandi:relation" and {t.__name__, klass.__name__} == {
                 "Resource",
                 "RelatedParticipant",
-            ):
+            }:
                 return
-            if qname in "dandi:approach" and klass.__name__ in (
+            if qname in "dandi:approach" and {t.__name__, klass.__name__} == {
                 "Asset",
                 "AssetsSummary",
-            ):
+            }:
                 return
-            if qname == "dandi:species" and klass.__name__ in (
+            if qname == "dandi:species" and {t.__name__, klass.__name__} == {
                 "Participant",
                 "AssetsSummary",
-            ):
+            }:
                 return
             raise ValueError(f"{qname},{klass} already exists {qnames[qname]}")
         qnames[qname] = klass

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -14,6 +14,7 @@ from .utils import DOI_PREFIX, INSTANCE_NAME, basic_publishmeta, skipif_no_doi_p
 from .. import models
 from ..models import (
     DANDI_INSTANCE_URL_PATTERN,
+    DANDI_NSKEY,
     AccessRequirements,
     AccessType,
     Affiliation,
@@ -550,7 +551,7 @@ def test_schemakey() -> None:
 
 
 def test_duplicate_classes() -> None:
-    qnames: Dict[str, Optional[type]] = {}
+    qnames: Dict[str, type] = {}
 
     def check_qname(qname: str, klass: type) -> None:
         if (
@@ -565,9 +566,8 @@ def test_duplicate_classes() -> None:
             return
         if qname in qnames:
             t = qnames[qname]
-            if t is None:
-                return
-            elif issubclass(klass, (t,)):
+
+            if issubclass(klass, (t,)):
                 return
             elif issubclass(t, klass):
                 qnames[qname] = klass
@@ -596,20 +596,18 @@ def test_duplicate_classes() -> None:
         qnames[qname] = klass
 
     modelnames = dir(models)
-    modelnames.remove("CommonModel")
-    modelnames.remove("BaseType")
     modelnames.remove("BaseModel")
     modelnames.remove("DandiBaseModel")
-    for val in ["CommonModel", "BaseType"] + modelnames:
+    for val in modelnames:
         klass = getattr(models, val)
         if not isclass(klass) or not issubclass(klass, pydantic.BaseModel):
             continue
         if hasattr(klass, "_ldmeta"):
+            name = klass.__name__
             if "nskey" in klass._ldmeta.default:
-                name = klass.__name__
                 qname = f'{klass._ldmeta.default["nskey"]}:{name}'
             else:
-                qname = f"dandi:{name}"
+                qname = f"{DANDI_NSKEY}:{name}"
             check_qname(qname, klass)
         for name, field in klass.model_fields.items():
             if (
@@ -618,7 +616,7 @@ def test_duplicate_classes() -> None:
             ):
                 qname = cast(str, field.json_schema_extra["nskey"]) + ":" + name
             else:
-                qname = f"dandi:{name}"
+                qname = f"{DANDI_NSKEY}:{name}"
             check_qname(qname, klass)
 
 


### PR DESCRIPTION
## Summary
- Fix a latent bug in `test_duplicate_classes` where `name` was only assigned inside the `_ldmeta` "nskey" branch, so the `else` branch could reuse a stale (or unbound) `name` left over from a previous iteration.
- Replace the hardcoded `"dandi"` qname prefix with the existing `DANDI_NSKEY` constant, drop dead code (`Optional` on the `qnames` dict and its unreachable `None` check), and stop special-casing the iteration order of `CommonModel` and `BaseType`, since the conflict-resolution logic already handles either registration order.
- Tighten the conflicting-qname exception checks to compare both class names as a set, instead of only checking that the newly seen class's name was one of the two allowed names, so each exception verifies both classes involved are exactly the expected pair.

## Test plan
- [x] `tox -e py3 -- dandischema/tests/test_models.py -v`
- [x] `tox -e lint,typing`