### PR TITLE
fix: guard against empty loc tuples; drop redundant list comprehensions

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -642,14 +642,14 @@ class DandiBaseModel(BaseModel):
                     value["type"] = "object"
                     del value["allOf"]
             if anyOf is not None:
-                if len(anyOf) > 1 and any(["$ref" in val for val in anyOf]):
+                if len(anyOf) > 1 and any("$ref" in val for val in anyOf):
                     value["type"] = "object"
             if items is not None:
                 anyOf = items.get("anyOf")
                 if (
                     anyOf is not None
                     and len(anyOf) > 1
-                    and any(["$ref" in val for val in anyOf])
+                    and any("$ref" in val for val in anyOf)
                 ):
                     value["items"]["type"] = "object"
             # In pydantic 1.8+ all Literals are mapped on to enum

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -316,7 +316,7 @@ def test_requirements(
         validate(obj, schema_key=schema_key)
     with pytest.raises(PydanticValidationError) as exc:
         validate(obj, schema_key=schema_key, schema_version=DANDI_SCHEMA_VERSION)
-    assert set([el["loc"][0] for el in exc.value.errors]) == missingfields
+    assert set(el["loc"][0] for el in exc.value.errors) == missingfields
 
 
 @pytest.mark.parametrize(

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -316,7 +316,10 @@ def test_requirements(
         validate(obj, schema_key=schema_key)
     with pytest.raises(PydanticValidationError) as exc:
         validate(obj, schema_key=schema_key, schema_version=DANDI_SCHEMA_VERSION)
-    assert set(el["loc"][0] for el in exc.value.errors) == missingfields
+    assert (
+        set(loc[0] if (loc := el["loc"]) else None for el in exc.value.errors)
+        == missingfields
+    )
 
 
 @pytest.mark.parametrize(

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -150,10 +150,8 @@ def test_asset_digest() -> None:
             contentSize=100, encodingFormat="nwb", digest=digest_model, path="/"
         )
     assert any(
-        [
-            "Digest must have an appropriate dandi-etag value." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "Digest must have an appropriate dandi-etag value." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
     digest = 32 * "a" + "-1"
     digest_model = {models.DigestType.dandi_etag: digest}
@@ -221,10 +219,8 @@ def test_asset_digest() -> None:
             path="/",
         )
     assert any(
-        [
-            "Digest must have an appropriate dandi-zarr-checksum value." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "Digest must have an appropriate dandi-zarr-checksum value." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
     digest = f"{32 * 'a'}-1--42"
     digest_model = {models.DigestType.dandi_zarr_checksum: digest}
@@ -236,10 +232,8 @@ def test_asset_digest() -> None:
             path="/",
         )
     assert any(
-        [
-            "contentSize 100 is not equal to the checksum size 42." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "contentSize 100 is not equal to the checksum size 42." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
     digest = f"{32 * 'a'}-1--100"
     digest_model = {models.DigestType.dandi_zarr_checksum: digest}
@@ -263,10 +257,8 @@ def test_asset_digest() -> None:
             path="/",
         )
     assert any(
-        [
-            "Digest cannot have both etag and zarr checksums." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "Digest cannot have both etag and zarr checksums." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
     with pytest.raises(pydantic.ValidationError) as exc:
         models.PublishedAsset(  # type: ignore[call-arg]
@@ -276,10 +268,8 @@ def test_asset_digest() -> None:
             path="/",
         )
     assert any(
-        [
-            "Digest cannot have both etag and zarr checksums." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "Digest cannot have both etag and zarr checksums." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
     digest_model = {}
     with pytest.raises(pydantic.ValidationError) as exc:
@@ -290,10 +280,8 @@ def test_asset_digest() -> None:
             path="/",
         )
     assert any(
-        [
-            "A zarr asset must have a zarr checksum." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "A zarr asset must have a zarr checksum." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
     with pytest.raises(pydantic.ValidationError) as exc:
         models.PublishedAsset(  # type: ignore[call-arg]
@@ -303,10 +291,8 @@ def test_asset_digest() -> None:
             path="/",
         )
     assert any(
-        [
-            "A zarr asset must have a zarr checksum." in val
-            for val in set([el["msg"] for el in exc.value.errors()])
-        ]
+        "A zarr asset must have a zarr checksum." in val
+        for val in set(el["msg"] for el in exc.value.errors())
     )
 
 
@@ -493,7 +479,7 @@ def test_dandimeta_1(base_dandiset_metadata: dict[str, Any]) -> None:
         if expected_errors[err_loc].msg is not None:
             assert err["msg"] == expected_errors[err_loc].msg
 
-    assert set([el["loc"][0] for el in exc.value.errors()]) == {
+    assert set(el["loc"][0] for el in exc.value.errors()) == {
         e
         for e in [
             "assetsSummary",
@@ -683,7 +669,7 @@ def test_schemakey_roundtrip() -> None:
     contributor[0]["name"] = "last, first"
     klassobj = TempKlass1(contributor=contributor)
     assert klassobj.contributor is not None and all(
-        [isinstance(val, Person) for val in klassobj.contributor]
+        isinstance(val, Person) for val in klassobj.contributor
     )
 
 

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -479,7 +479,7 @@ def test_dandimeta_1(base_dandiset_metadata: dict[str, Any]) -> None:
         if expected_errors[err_loc].msg is not None:
             assert err["msg"] == expected_errors[err_loc].msg
 
-    assert set(el["loc"][0] for el in exc.value.errors()) == {
+    assert set(loc[0] if (loc := el["loc"]) else None for el in exc.value.errors()) == {
         e
         for e in [
             "assetsSummary",


### PR DESCRIPTION
## Summary
- Fix a latent `IndexError`: `pydantic.ValidationError`'s `ErrorDetails.loc` is a tuple that can be empty for model-level (root) validator errors, so unconditionally indexing it at position `0` is unsafe; two test sites now guard against this.
- Drop redundant list comprehensions passed to `any()`, `all()`, and `set()`, which all consume an iterable directly, so wrapping a generator expression in a list comprehension first was unnecessary.

## Test plan
- [x] `tox -e py3` passes
- [x] `tox -e lint,typing` passes
