### PR TITLE
fix: sort `LicenseType` members by value for reproducible schemas

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -120,9 +120,13 @@ if TYPE_CHECKING:
         ...  # fmt: skip
 
 else:
+    # `sorted()` makes the member order, and hence the JSON schema, consistent.
     LicenseType = Enum(
         "LicenseType",
-        [(license_.name, license_.value) for license_ in _INSTANCE_CONFIG.licenses],
+        [
+            (license_.name, license_.value)
+            for license_ in sorted(_INSTANCE_CONFIG.licenses, key=lambda lic: lic.value)
+        ],
     )
     r"""
     An enumeration of supported licenses


### PR DESCRIPTION
Fixes #433.

## Problem

`LicenseType` is built by iterating `Config.licenses`, which is a `set`. The order of iterating a `set` of `Enum` members depends on `PYTHONHASHSEED`, which CPython randomizes per process, so the member order of `LicenseType` varied from process to process.

That member order is what fixes the order of the elements in the `enum` array of the `LicenseType` definition under `$defs`, which is emitted into all four generated JSON Schemas (`dandiset.json`, `published-dandiset.json`, `asset.json`, `published-asset.json`). Two invocations of `tools/pubschemata.py` on the same commit could therefore emit different files.

## Fix

Sort the members by value when building the enum. `Config.licenses` stays a `set`, with the sort applied at the single point where the order becomes observable. Validation behavior is unchanged, since JSON Schema `enum` is order-insensitive.

## Merge order

Recommend merging to master before #419 is released. This PR carries no `DANDI_SCHEMA_VERSION` bump, since #419 already bumps it to `0.8.0`. The fix settles the order on `["spdx:CC-BY-4.0", "spdx:CC0-1.0"]`, which differs from what `dandi/schema` `releases/0.7.0/` holds, so merging ahead of #419's release lets `0.8.0` be published once with the sorted order.

## Test plan

- [x] `LicenseType` member order is identical across `PYTHONHASHSEED` in `{0, 1, 2, 3, 4, 5, 42, 1234}`
- [x] `tools/pubschemata.py` output is byte-identical between seeds 0 and 3; before the fix, all four schema files differed
- [x] `pytest dandischema`: 258 passed, 19 skipped
- [x] `pre-commit` and `mypy` clean
