### PR TITLE
chore: auto - run "released" plugin before "exec"

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -4,12 +4,12 @@
     "noVersionPrefix": true,
     "plugins": [
         "git-tag",
+        "released",
         [
             "exec",
             {
                   "afterRelease": "python -m build && twine upload dist/*"
             }
-        ],
-        "released"
+        ]
     ]
 }


### PR DESCRIPTION
Otherwise, if we fail to run that "exec" due to "too big of changelog" we no longer have PRs and issues properly annotated by released. If we fail after -- we can just handle pypi release (+ manually potentially tagging, minting and pushing new schema-).

Overall -- something to streamline even more... may be we could avoid that "exec" altogether and just move it to github action or smth like that